### PR TITLE
feat(problem-submission): 제출 저장 및 일일 통계 갱신 로직 구현

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
@@ -18,7 +18,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 폴더 관련 에러
     FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER4041", "존재하지 않는 폴더입니다."),
-    FOLDER_NOT_LEAF(HttpStatus.BAD_REQUEST, "FOLDER4001", "연습 문제 조회는 leaf 폴더에서만 가능합니다.");
+    FOLDER_NOT_LEAF(HttpStatus.BAD_REQUEST, "FOLDER4001", "연습 문제 조회는 leaf 폴더에서만 가능합니다."),
+
+    // 문제 관련 에러
+    PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROBLEM4041", "존재하지 않는 문제입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailystat/entity/DailyStat.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailystat/entity/DailyStat.java
@@ -1,6 +1,11 @@
 package com.hhd1337.jatuli_quiz.domain.dailystat.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -44,5 +49,36 @@ public class DailyStat {
         this.focusSeconds = focusSeconds;
         this.accumulatedFocusSeconds = accumulatedFocusSeconds;
         this.daysInARow = daysInARow;
+    }
+
+    public static DailyStat createFirstSubmissionOfDay(
+            LocalDate statDate,
+            int elapsedSeconds,
+            long previousAccumulatedFocusSeconds,
+            int daysInARow
+    ) {
+        return new DailyStat(
+                statDate,
+                1,
+                elapsedSeconds,
+                previousAccumulatedFocusSeconds + elapsedSeconds,
+                daysInARow
+        );
+    }
+
+    public void applySubmission(int elapsedSeconds) {
+        if (this.solvedCount == null) {
+            this.solvedCount = 0;
+        }
+        if (this.focusSeconds == null) {
+            this.focusSeconds = 0;
+        }
+        if (this.accumulatedFocusSeconds == null) {
+            this.accumulatedFocusSeconds = 0L;
+        }
+
+        this.solvedCount += 1;
+        this.focusSeconds += elapsedSeconds;
+        this.accumulatedFocusSeconds += elapsedSeconds;
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailystat/repository/DailyStatRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailystat/repository/DailyStatRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DailyStatRepository extends JpaRepository<DailyStat, Long> {
     Optional<DailyStat> findByStatDate(LocalDate statDate);
+    
+    Optional<DailyStat> findTopByStatDateLessThanOrderByStatDateDesc(LocalDate statDate);
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/entity/Problem.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/entity/Problem.java
@@ -68,4 +68,11 @@ public class Problem {
         this.solvedCount = solvedCount;
         this.folder = folder;
     }
+
+    public void increaseSolvedCount() {
+        if (this.solvedCount == null) {
+            this.solvedCount = 0;
+        }
+        this.solvedCount += 1;
+    }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/ProblemSubmissionRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/ProblemSubmissionRestController.java
@@ -1,0 +1,38 @@
+package com.hhd1337.jatuli_quiz.domain.problemsubmission;
+
+import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.dto.ProblemSubmissionRequest;
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.dto.ProblemSubmissionResponse;
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.service.ProblemSubmissionCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/problem-submissions")
+@RequiredArgsConstructor
+public class ProblemSubmissionRestController {
+
+    private final ProblemSubmissionCommandService problemSubmissionCommandService;
+
+    @Operation(
+            summary = "문제 제출 결과 저장",
+            description = """
+                    한 문제를 풀었을 때의 제출 결과를 저장합니다.
+                    problemId는 필수이며, isCorrect와 elapsedSeconds는 선택값입니다.
+                    제출 시 problem의 attemptCount(solvedCount)를 1 증가시키고,
+                    DailyStat의 오늘 solvedCount / focusSeconds / accumulatedFocusSeconds를 함께 갱신합니다.
+                    오늘 첫 제출인 경우 daysInARow도 함께 갱신합니다.
+                    """
+    )
+    @PostMapping
+    public ApiResponse<ProblemSubmissionResponse.CreateProblemSubmissionResponse> submit(
+            @Valid @RequestBody ProblemSubmissionRequest.CreateProblemSubmissionRequest request
+    ) {
+        return ApiResponse.onSuccess(problemSubmissionCommandService.submit(request));
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/converter/ProblemSubmissionConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/converter/ProblemSubmissionConverter.java
@@ -1,0 +1,25 @@
+package com.hhd1337.jatuli_quiz.domain.problemsubmission.converter;
+
+import com.hhd1337.jatuli_quiz.domain.dailystat.entity.DailyStat;
+import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.dto.ProblemSubmissionResponse;
+
+public class ProblemSubmissionConverter {
+
+    private ProblemSubmissionConverter() {
+    }
+
+    public static ProblemSubmissionResponse.CreateProblemSubmissionResponse toCreateProblemSubmissionResponse(
+            Problem problem,
+            DailyStat dailyStat
+    ) {
+        return ProblemSubmissionResponse.CreateProblemSubmissionResponse.builder()
+                .problemId(problem.getProblemId())
+                .attemptCount(problem.getSolvedCount())
+                .todaySolvedCount(dailyStat.getSolvedCount())
+                .todayFocusSeconds(dailyStat.getFocusSeconds())
+                .accumulatedFocusSeconds(dailyStat.getAccumulatedFocusSeconds())
+                .daysInARow(dailyStat.getDaysInARow())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/dto/ProblemSubmissionRequest.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/dto/ProblemSubmissionRequest.java
@@ -1,0 +1,21 @@
+package com.hhd1337.jatuli_quiz.domain.problemsubmission.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ProblemSubmissionRequest {
+    @Getter
+    @NoArgsConstructor
+    public static class CreateProblemSubmissionRequest {
+
+        @NotNull
+        private Long problemId;
+
+        private Boolean isCorrect;
+
+        @PositiveOrZero
+        private Integer elapsedSeconds;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/dto/ProblemSubmissionResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/dto/ProblemSubmissionResponse.java
@@ -1,0 +1,20 @@
+package com.hhd1337.jatuli_quiz.domain.problemsubmission.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ProblemSubmissionResponse {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CreateProblemSubmissionResponse {
+        private Long problemId;
+        private Integer attemptCount;
+        private Integer todaySolvedCount;
+        private Integer todayFocusSeconds;
+        private Long accumulatedFocusSeconds;
+        private Integer daysInARow;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/entity/ProblemSubmission.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/entity/ProblemSubmission.java
@@ -1,0 +1,53 @@
+package com.hhd1337.jatuli_quiz.domain.problemsubmission.entity;
+
+import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "problem_submission")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProblemSubmission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "problem_submission_id")
+    private Long problemSubmissionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem;
+
+    @Column(name = "is_correct")
+    private Boolean isCorrect;
+
+    @Column(name = "elapsed_seconds")
+    private Integer elapsedSeconds;
+
+    @Column(name = "submitted_at", nullable = false)
+    private LocalDateTime submittedAt;
+
+    public ProblemSubmission(
+            Problem problem,
+            Boolean isCorrect,
+            Integer elapsedSeconds,
+            LocalDateTime submittedAt
+    ) {
+        this.problem = problem;
+        this.isCorrect = isCorrect;
+        this.elapsedSeconds = elapsedSeconds;
+        this.submittedAt = submittedAt;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/repository/ProblemSubmissionRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/repository/ProblemSubmissionRepository.java
@@ -1,0 +1,7 @@
+package com.hhd1337.jatuli_quiz.domain.problemsubmission.repository;
+
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.entity.ProblemSubmission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemSubmissionRepository extends JpaRepository<ProblemSubmission, Long> {
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/service/ProblemSubmissionCommandService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/service/ProblemSubmissionCommandService.java
@@ -1,0 +1,11 @@
+package com.hhd1337.jatuli_quiz.domain.problemsubmission.service;
+
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.dto.ProblemSubmissionRequest;
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.dto.ProblemSubmissionResponse;
+
+public interface ProblemSubmissionCommandService {
+
+    ProblemSubmissionResponse.CreateProblemSubmissionResponse submit(
+            ProblemSubmissionRequest.CreateProblemSubmissionRequest request
+    );
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/service/ProblemSubmissionCommandServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/service/ProblemSubmissionCommandServiceImpl.java
@@ -1,0 +1,99 @@
+package com.hhd1337.jatuli_quiz.domain.problemsubmission.service;
+
+import com.hhd1337.jatuli_quiz.common.exception.GeneralException;
+import com.hhd1337.jatuli_quiz.common.exception.code.status.ErrorStatus;
+import com.hhd1337.jatuli_quiz.domain.dailystat.entity.DailyStat;
+import com.hhd1337.jatuli_quiz.domain.dailystat.repository.DailyStatRepository;
+import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.converter.ProblemSubmissionConverter;
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.dto.ProblemSubmissionRequest;
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.dto.ProblemSubmissionResponse;
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.entity.ProblemSubmission;
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.repository.ProblemSubmissionRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProblemSubmissionCommandServiceImpl implements ProblemSubmissionCommandService {
+
+    private final ProblemRepository problemRepository;
+    private final ProblemSubmissionRepository problemSubmissionRepository;
+    private final DailyStatRepository dailyStatRepository;
+
+    @Override
+    public ProblemSubmissionResponse.CreateProblemSubmissionResponse submit(
+            ProblemSubmissionRequest.CreateProblemSubmissionRequest request
+    ) {
+        Problem problem = problemRepository.findById(request.getProblemId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PROBLEM_NOT_FOUND));
+
+        int elapsedSeconds = request.getElapsedSeconds() == null ? 0 : request.getElapsedSeconds();
+
+        problem.increaseSolvedCount();
+
+        ProblemSubmission submission = new ProblemSubmission(
+                problem,
+                request.getIsCorrect(),
+                elapsedSeconds,
+                LocalDateTime.now()
+        );
+        problemSubmissionRepository.save(submission);
+
+        DailyStat dailyStat = updateDailyStat(elapsedSeconds);
+
+        return ProblemSubmissionConverter.toCreateProblemSubmissionResponse(problem, dailyStat);
+    }
+
+    private DailyStat updateDailyStat(int elapsedSeconds) {
+        LocalDate today = LocalDate.now();
+
+        Optional<DailyStat> todayStatOptional = dailyStatRepository.findByStatDate(today);
+
+        if (todayStatOptional.isPresent()) {
+            DailyStat todayStat = todayStatOptional.get();
+            todayStat.applySubmission(elapsedSeconds);
+            return todayStat;
+        }
+
+        Optional<DailyStat> lastStatOptional =
+                dailyStatRepository.findTopByStatDateLessThanOrderByStatDateDesc(today);
+
+        long previousAccumulatedFocusSeconds = lastStatOptional
+                .map(DailyStat::getAccumulatedFocusSeconds)
+                .orElse(0L);
+
+        int daysInARow = calculateDaysInARow(lastStatOptional, today);
+
+        DailyStat newDailyStat = DailyStat.createFirstSubmissionOfDay(
+                today,
+                elapsedSeconds,
+                previousAccumulatedFocusSeconds,
+                daysInARow
+        );
+
+        return dailyStatRepository.save(newDailyStat);
+    }
+
+    private int calculateDaysInARow(Optional<DailyStat> lastStatOptional, LocalDate today) {
+        if (lastStatOptional.isEmpty()) {
+            return 1;
+        }
+
+        DailyStat lastStat = lastStatOptional.get();
+        LocalDate yesterday = today.minusDays(1);
+
+        if (yesterday.equals(lastStat.getStatDate())) {
+            Integer previousDaysInARow = lastStat.getDaysInARow();
+            return (previousDaysInARow == null ? 0 : previousDaysInARow) + 1;
+        }
+
+        return 1;
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용 설명

문제 풀이 결과를 저장하는 **Problem Submission 기능**을 구현했다.
사용자가 문제를 풀고 제출하면 다음 정보가 저장된다.

- problemId
- 정답 여부 (isCorrect)
- 문제 풀이 소요 시간 (elapsedSeconds)

제출 시 다음 데이터가 함께 갱신된다.

1. Problem
- solvedCount 증가 (attemptCount 역할)

2. DailyStat
- 오늘 푼 문제 수 (solvedCount)
- 오늘 학습 시간 (focusSeconds)
- 전체 누적 학습 시간 (accumulatedFocusSeconds)
- 연속 학습일 (daysInARow)

또한 제출 이후 최신 attemptCount와 오늘 통계 정보를 응답으로 반환하도록 구현했다.