### PR TITLE
feat(problem): 문제 북마크 토글 API 구현

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
@@ -1,0 +1,35 @@
+package com.hhd1337.jatuli_quiz.domain.problem;
+
+import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.service.ProblemCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/problems")
+@RequiredArgsConstructor
+public class ProblemRestController {
+
+    private final ProblemCommandService problemCommandService;
+
+    @Operation(
+            summary = "문제 북마크 토글",
+            description = """
+                    문제 상세/풀이 화면에서 북마크 아이콘 클릭 시 북마크 상태를 토글합니다.
+                    현재 MVP에서는 단일 사용자 기준으로 Problem의 isBookmarked 값을 직접 변경합니다.
+                    호출할 때마다 true/false가 반전되며, 최신 isBookmarked 값을 반환합니다.
+                    존재하지 않는 problemId 요청 시 예외를 반환합니다.
+                    """
+    )
+    @PostMapping("/{problemId}/bookmark")
+    public ApiResponse<ProblemBookmarkResponse.ToggleBookmarkResponse> toggleBookmark(
+            @PathVariable Long problemId
+    ) {
+        return ApiResponse.onSuccess(problemCommandService.toggleBookmark(problemId));
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/converter/ProblemConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/converter/ProblemConverter.java
@@ -1,0 +1,17 @@
+package com.hhd1337.jatuli_quiz.domain.problem.converter;
+
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+
+public class ProblemConverter {
+
+    private ProblemConverter() {
+    }
+
+    public static ProblemBookmarkResponse.ToggleBookmarkResponse toToggleBookmarkResponse(Problem problem) {
+        return ProblemBookmarkResponse.ToggleBookmarkResponse.builder()
+                .problemId(problem.getProblemId())
+                .isBookmarked(problem.getIsBookmarked())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ProblemBookmarkResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ProblemBookmarkResponse.java
@@ -1,0 +1,16 @@
+package com.hhd1337.jatuli_quiz.domain.problem.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ProblemBookmarkResponse {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ToggleBookmarkResponse {
+        private Long problemId;
+        private Boolean isBookmarked;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/entity/Problem.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/entity/Problem.java
@@ -75,4 +75,12 @@ public class Problem {
         }
         this.solvedCount += 1;
     }
+
+    public void toggleBookmark() {
+        if (this.isBookmarked == null) {
+            this.isBookmarked = true;
+            return;
+        }
+        this.isBookmarked = !this.isBookmarked;
+    }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandService.java
@@ -1,0 +1,8 @@
+package com.hhd1337.jatuli_quiz.domain.problem.service;
+
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
+
+public interface ProblemCommandService {
+
+    ProblemBookmarkResponse.ToggleBookmarkResponse toggleBookmark(Long problemId);
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
@@ -1,0 +1,29 @@
+package com.hhd1337.jatuli_quiz.domain.problem.service;
+
+import com.hhd1337.jatuli_quiz.common.exception.GeneralException;
+import com.hhd1337.jatuli_quiz.common.exception.code.status.ErrorStatus;
+import com.hhd1337.jatuli_quiz.domain.problem.converter.ProblemConverter;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProblemCommandServiceImpl implements ProblemCommandService {
+
+    private final ProblemRepository problemRepository;
+
+    @Override
+    public ProblemBookmarkResponse.ToggleBookmarkResponse toggleBookmark(Long problemId) {
+        Problem problem = problemRepository.findById(problemId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PROBLEM_NOT_FOUND));
+
+        problem.toggleBookmark();
+
+        return ProblemConverter.toToggleBookmarkResponse(problem);
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용 설명

문제 상세/풀이 화면에서 북마크 아이콘 클릭 시 북마크 상태를 토글하는 API를 구현.

현재 MVP에서는 단일 사용자 기준으로 `Problem.isBookmarked` 값을 직접 변경하도록 구성함.
호출할 때마다 `isBookmarked` 값이 true/false로 반전되며, 최신 북마크 상태를 응답으로 반환함.

---

## ✅ 작업한 내용

- [x] `POST /api/v1/problems/{problemId}/bookmark` API 구현
- [x] `Problem.isBookmarked` 토글 메서드 추가
- [x] 북마크 토글 응답 DTO 작성
- [x] ProblemCommandService / Impl 구현
- [x] ProblemRestController 엔드포인트 추가
- [x] 존재하지 않는 problemId 요청에 대한 예외 처리 추가
- [x] 북마크 토글 서비스 테스트 작성

---

## 관련 이슈
- Closes https://github.com/hhd1337/jatuli-quiz/issues/10