### PR TITLE
feat(practice): 북마크 문제 연습 조회 로직 구현

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/PracticeRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/PracticeRestController.java
@@ -1,0 +1,32 @@
+package com.hhd1337.jatuli_quiz.domain.practice;
+
+import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
+import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
+import com.hhd1337.jatuli_quiz.domain.practice.service.PracticeQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/practice")
+@RequiredArgsConstructor
+public class PracticeRestController {
+
+    private final PracticeQueryService practiceQueryService;
+
+    @Operation(
+            summary = "북마크 문제 연습 세트 조회",
+            description = """
+                    사용자가 북마크한 문제들만 모아 연습 세트로 반환합니다.
+                    현재 MVP에서는 북마크된 문제들을 attemptCount(solvedCount) 오름차순으로 정렬하여 반환합니다.
+                    응답 형식은 selectionRule, problems 배열로 통일합니다.
+                    북마크된 문제가 없으면 빈 배열을 반환합니다.
+                    """
+    )
+    @PostMapping("/bookmarks")
+    public ApiResponse<PracticeResponse.GetPracticeProblemsResponse> getBookmarkedPracticeProblems() {
+        return ApiResponse.onSuccess(practiceQueryService.getBookmarkedPracticeProblems());
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/converter/PracticeConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/converter/PracticeConverter.java
@@ -1,0 +1,37 @@
+package com.hhd1337.jatuli_quiz.domain.practice.converter;
+
+import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+import java.util.List;
+
+public class PracticeConverter {
+
+    private PracticeConverter() {
+    }
+
+    public static PracticeResponse.PracticeProblemDto toPracticeProblemDto(Problem problem) {
+        return PracticeResponse.PracticeProblemDto.builder()
+                .problemId(problem.getProblemId())
+                .problemNum(problem.getProblemNum())
+                .question(problem.getQuestionText())
+                .answer(problem.getAnswerText())
+                .explanation(problem.getExplanationText())
+                .meta(
+                        PracticeResponse.PracticeProblemMetaDto.builder()
+                                .attemptCount(problem.getSolvedCount() == null ? 0 : problem.getSolvedCount())
+                                .isBookmarked(problem.getIsBookmarked())
+                                .build()
+                )
+                .build();
+    }
+
+    public static PracticeResponse.GetPracticeProblemsResponse toGetPracticeProblemsResponse(
+            String selectionRule,
+            List<PracticeResponse.PracticeProblemDto> problems
+    ) {
+        return PracticeResponse.GetPracticeProblemsResponse.builder()
+                .selectionRule(selectionRule)
+                .problems(problems)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/dto/PracticeResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/dto/PracticeResponse.java
@@ -1,0 +1,37 @@
+package com.hhd1337.jatuli_quiz.domain.practice.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class PracticeResponse {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class GetPracticeProblemsResponse {
+        private String selectionRule;
+        private List<PracticeProblemDto> problems;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class PracticeProblemDto {
+        private Long problemId;
+        private Integer problemNum;
+        private String question;
+        private String answer;
+        private String explanation;
+        private PracticeProblemMetaDto meta;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class PracticeProblemMetaDto {
+        private Integer attemptCount;
+        private Boolean isBookmarked;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/PracticeQueryService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/PracticeQueryService.java
@@ -1,0 +1,8 @@
+package com.hhd1337.jatuli_quiz.domain.practice.service;
+
+import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
+
+public interface PracticeQueryService {
+
+    PracticeResponse.GetPracticeProblemsResponse getBookmarkedPracticeProblems();
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/PracticeQueryServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/PracticeQueryServiceImpl.java
@@ -1,0 +1,34 @@
+package com.hhd1337.jatuli_quiz.domain.practice.service;
+
+import com.hhd1337.jatuli_quiz.domain.practice.converter.PracticeConverter;
+import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PracticeQueryServiceImpl implements PracticeQueryService {
+
+    private static final String SELECTION_RULE_BOOKMARK_ATTEMPT_ASC = "BOOKMARK_ATTEMPT_ASC";
+
+    private final ProblemRepository problemRepository;
+
+    @Override
+    public PracticeResponse.GetPracticeProblemsResponse getBookmarkedPracticeProblems() {
+        List<Problem> bookmarkedProblems = problemRepository.findBookmarkedProblemsOrderByAttemptCountAsc();
+
+        List<PracticeResponse.PracticeProblemDto> problems = bookmarkedProblems.stream()
+                .map(PracticeConverter::toPracticeProblemDto)
+                .toList();
+
+        return PracticeConverter.toGetPracticeProblemsResponse(
+                SELECTION_RULE_BOOKMARK_ATTEMPT_ASC,
+                problems
+        );
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
@@ -23,4 +23,14 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
                   and p.solvedCount > 0
             """)
     Integer countSolvedProblemsByFolderId(Long folderId);
+
+    List<Problem> findAllByIsBookmarkedTrueOrderBySolvedCountAscProblemIdAsc();
+
+    @Query("""
+            select p
+            from Problem p
+            where p.isBookmarked = true
+            order by coalesce(p.solvedCount, 0) asc, p.problemId asc
+            """)
+    List<Problem> findBookmarkedProblemsOrderByAttemptCountAsc();
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
@@ -23,9 +23,7 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
                   and p.solvedCount > 0
             """)
     Integer countSolvedProblemsByFolderId(Long folderId);
-
-    List<Problem> findAllByIsBookmarkedTrueOrderBySolvedCountAscProblemIdAsc();
-
+    
     @Query("""
             select p
             from Problem p


### PR DESCRIPTION
## 📝 작업 내용 설명

사용자가 북마크한 문제들만 모아 연습 세트로 반환하는 API를 구현함.  
프론트의 **북마크 연습 기능**과 1:1로 대응하도록 설계했으며,  
현재 MVP에서는 단일 사용자 기준으로 북마크된 문제 전체를 조회하여 반환한다.

응답 구조는 기존 연습 API와 동일하게 `selectionRule + problems[]` 형식을 사용해  
연습 세트 API 간 응답 구조를 통일했다.

또한 북마크 문제는 학습 우선순위를 고려할 수 있도록  
`attemptCount` 기반 정렬(또는 랜덤 선택) 정책을 확장 가능하도록 설계했다.

---

## ✅ 작업 내용

- [x] `POST /api/v1/practice/bookmarks` API 설계 및 구현
- [x] 북마크된 문제 목록 조회 로직 구현
- [x] `attemptCount` 기준 정렬 정책 적용 (확장 가능 구조로 설계)
- [x] 연습 API 응답 형식 통일 (`selectionRule`, `problems[]`)
- [x] 문제별 메타 정보 포함
  - `attemptCount`
  - `isBookmarked`
- [x] 북마크된 문제가 없는 경우 빈 배열 반환 처리
- [x] 응답 DTO (`PracticeResponse`) 재사용
- [x] 서비스 레이어 로직 구현 (`PracticeQueryService`)
- [x] 컨트롤러 엔드포인트 추가
- [x] Swagger `@Operation` 설명 추가