### PR TITLE
feat(practice): 랜덤 연습 세트 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/PracticeRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/PracticeRestController.java
@@ -29,4 +29,18 @@ public class PracticeRestController {
     public ApiResponse<PracticeResponse.GetPracticeProblemsResponse> getBookmarkedPracticeProblems() {
         return ApiResponse.onSuccess(practiceQueryService.getBookmarkedPracticeProblems());
     }
+
+    @Operation(
+            summary = "랜덤 연습 세트 조회",
+            description = """
+                    전체 문제 중 랜덤으로 연습 세트를 반환합니다.
+                    현재 MVP에서는 요청 바디 없이 기본 10문제를 랜덤으로 선택하며, 중복 없이 반환합니다.
+                    전체 문제가 10개보다 적으면 존재하는 문제만 반환합니다.
+                    응답 형식은 북마크 연습과 동일하게 selectionRule, problems 배열을 사용합니다.
+                    """
+    )
+    @PostMapping("/random")
+    public ApiResponse<PracticeResponse.GetPracticeProblemsResponse> getRandomPracticeProblems() {
+        return ApiResponse.onSuccess(practiceQueryService.getRandomPracticeProblems());
+    }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/PracticeQueryService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/PracticeQueryService.java
@@ -5,4 +5,6 @@ import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
 public interface PracticeQueryService {
 
     PracticeResponse.GetPracticeProblemsResponse getBookmarkedPracticeProblems();
+
+    PracticeResponse.GetPracticeProblemsResponse getRandomPracticeProblems();
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/PracticeQueryServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/PracticeQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.hhd1337.jatuli_quiz.domain.practice.converter.PracticeConverter;
 import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
 import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class PracticeQueryServiceImpl implements PracticeQueryService {
 
     private static final String SELECTION_RULE_BOOKMARK_ATTEMPT_ASC = "BOOKMARK_ATTEMPT_ASC";
+    private static final String SELECTION_RULE_RANDOM = "RANDOM";
+    private static final int RANDOM_PRACTICE_SIZE = 10;
 
     private final ProblemRepository problemRepository;
 
@@ -28,6 +31,26 @@ public class PracticeQueryServiceImpl implements PracticeQueryService {
 
         return PracticeConverter.toGetPracticeProblemsResponse(
                 SELECTION_RULE_BOOKMARK_ATTEMPT_ASC,
+                problems
+        );
+    }
+
+    @Override
+    public PracticeResponse.GetPracticeProblemsResponse getRandomPracticeProblems() {
+        List<Problem> allProblems = problemRepository.findAll();
+
+        Collections.shuffle(allProblems);
+
+        List<Problem> selectedProblems = allProblems.stream()
+                .limit(RANDOM_PRACTICE_SIZE)
+                .toList();
+
+        List<PracticeResponse.PracticeProblemDto> problems = selectedProblems.stream()
+                .map(PracticeConverter::toPracticeProblemDto)
+                .toList();
+
+        return PracticeConverter.toGetPracticeProblemsResponse(
+                SELECTION_RULE_RANDOM,
                 problems
         );
     }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/problems")
+@RequestMapping("/problems")
 @RequiredArgsConstructor
 public class ProblemRestController {
 

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/ProblemSubmissionRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/ProblemSubmissionRestController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/problem-submissions")
+@RequestMapping("/problem-submissions")
 @RequiredArgsConstructor
 public class ProblemSubmissionRestController {
 


### PR DESCRIPTION
## 📝 작업 내용 설명

전체 문제 중 랜덤으로 연습 세트를 생성하여 반환하는 API를 구현함.
MVP 단계에서는 요청 바디 없이 기본적으로 10개의 문제를 랜덤 선택하여 반환하도록 설계.
문제 선택 시 중복 없이 랜덤 추출되도록 구현했으며, 전체 문제가 10개 미만일 경우 존재하는 문제만 반환한다.

응답 형식은 기존 연습 API(폴더 연습, 북마크 연습)와 동일하게  
`selectionRule + problems[]` 구조를 유지하여 연습 API 응답 포맷을 통일하였다.

---

## ✅ 작업 내용

- [x] `POST /api/v1/practice/random` API 설계 및 구현
- [x] 전체 문제 중 랜덤 선택 로직 구현 (`Collections.shuffle`)
- [x] 기본 랜덤 문제 개수 `size = 10` 적용
- [x] 중복 없이 문제 선택하도록 구현
- [x] 전체 문제가 10개 미만일 경우 존재하는 문제만 반환 처리
- [x] 응답 포맷 통일 (`selectionRule`, `problems[]`)
- [x] `selectionRule = RANDOM` 규칙 적용
- [x] `PracticeResponse` DTO 재사용
- [x] `PracticeConverter` 활용한 DTO 변환 로직 구현
- [x] Swagger `@Operation` 설명 추가

---

## 🔗 관련 이슈

- Closes https://github.com/hhd1337/jatuli-quiz/issues/8