### PR TITLE
feat(backend/ci): 도커 배포용 설정 및 헬스체크 엔드포인트 추가

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:21-jdk
+
+WORKDIR /app
+
+COPY build/libs/jatuli-quiz-0.0.1-SNAPSHOT.jar app.jar
+
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "app.jar"]

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/infra/health/HealthController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/infra/health/HealthController.java
@@ -1,0 +1,13 @@
+package com.hhd1337.jatuli_quiz.infra.health;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/health")
+    public String health() {
+        return "ok";
+    }
+}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false


### PR DESCRIPTION

## 📝 작업 내용 설명

Docker 기반 배포를 진행하기 전에 필요한 기본 운영 설정을 먼저 반영했습니다.

이번 PR에서는 백엔드 애플리케이션이 운영 환경에서 실행될 수 있도록 `prod` 프로필 설정을 추가하고, Docker 이미지 생성을 위한 `Dockerfile`을 작성했습니다.  
또한 배포 후 서버 기동 여부를 빠르게 확인할 수 있도록 헬스체크 엔드포인트를 추가했습니다.

이번 변경은 CI/CD 전체 완성이 아니라, 이후 EC2 배포 / RDS 연결 / GitHub Actions 자동배포 작업으로 이어지기 위한 1차 기반 작업입니다.

## ✅ 작업 내용

- [x] `application-prod.yml` 추가 및 운영 환경 DB 설정 분리
- [x] 환경변수 기반 DB 연결 설정 적용 (`DB_URL`, `DB_USERNAME`, `DB_PASSWORD`)
- [x] Docker 배포용 `Dockerfile` 추가
- [x] 배포 확인용 `/health` 헬스체크 엔드포인트 추가
- [x] 로컬 Docker 이미지 빌드 및 컨테이너 실행 확인

---

## 🔗 관련 이슈

- Closes https://github.com/hhd1337/jatuli-quiz/issues/21