### PR TITLE
feat(backend/ci): backend GHCR 자동배포 워크플로우 추가

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,0 +1,72 @@
+name: Backend Deploy to EC2 via GHCR
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-deploy.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      IMAGE_NAME: ghcr.io/hhd1337/jatuli-quiz-backend:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./backend/gradlew
+
+      - name: Build bootJar
+        working-directory: ./backend
+        run: ./gradlew clean bootJar --no-daemon -x test
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_NAME }}
+
+      - name: Deploy on EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} -p ${{ secrets.GHCR_PAT }}
+            docker pull ${{ env.IMAGE_NAME }}
+            docker rm -f jatuli-backend-container || true
+            docker run -d \
+              --name jatuli-backend-container \
+              --restart unless-stopped \
+              -p 8080:8080 \
+              -e DB_URL='${{ secrets.DB_URL }}' \
+              -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \
+              -e DB_PASSWORD='${{ secrets.DB_PASSWORD }}' \
+              ${{ env.IMAGE_NAME }}
+            docker image prune -f


### PR DESCRIPTION
## 📝 작업 내용 설명

모노레포 구조를 유지하면서 backend 서비스만 독립적으로 자동배포할 수 있도록 GitHub Actions 워크플로우를 추가했습니다.

이번 PR에서는 `backend/**` 경로 변경 시에만 실행되는 backend 전용 배포 파이프라인을 구성하고, GitHub Container Registry(GHCR)에 Docker 이미지를 빌드 및 푸시한 뒤, EC2에서 최신 이미지를 pull 받아 컨테이너를 재실행하도록 자동화했습니다.  
이를 통해 EC2에서 직접 빌드하지 않고, GitHub Actions가 빌드와 이미지 생성을 담당하고 EC2는 실행만 수행하는 구조로 전환했습니다.

이번 변경은 모노레포 기반 서비스별 CI/CD 분리를 위한 backend 자동배포 파이프라인 작업입니다.

## ✅ 작업 내용

- [x] `.github/workflows/backend-deploy.yml` 추가
- [x] `main` 브랜치 기준 backend 변경 시에만 실행되도록 `paths` 조건 설정
- [x] GitHub Actions에서 Java 21 환경 구성 및 backend `bootJar` 빌드 설정
- [x] GHCR 로그인 및 Docker 이미지 빌드/푸시 자동화
- [x] EC2 SSH 접속 후 최신 이미지 pull 및 컨테이너 재실행 자동화
- [x] 기존 컨테이너 교체 방식의 backend 자동배포 흐름 구성

---

## 🔗 관련 이슈

- Closes https://github.com/hhd1337/jatuli-quiz/issues/21