### PR TITLE
chore(frontend/ci): 프론트엔드 Vercel 기반 자동배포 파이프라인 구축

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,0 +1,40 @@
+name: Frontend Deploy to Vercel
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-deploy.yml"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy to Vercel
+        run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }} --yes
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.vercel

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## 📝 작업 내용 설명

모노레포 구조를 유지하면서 frontend 서비스만 독립적으로 자동배포할 수 있도록 GitHub Actions 워크플로우를 추가했습니다.

이번 PR에서는 `frontend/**` 경로 변경 시에만 실행되는 frontend 전용 배포 파이프라인을 구성하고, GitHub Actions에서 frontend 빌드 후 Vercel CLI를 통해 production 배포가 이루어지도록 자동화했습니다.  
이를 통해 frontend는 backend와 분리된 독립 배포 구조를 가지면서도, 모노레포 내에서 서비스별 CI/CD를 각각 운영할 수 있도록 구성했습니다.

또한 React Router 기반 SPA 환경에서 직접 URL 접근 시에도 정상적으로 라우팅되도록 `vercel.json`을 추가하여 rewrite 설정을 적용했습니다.

이번 변경은 모노레포 기반 서비스별 CI/CD 분리를 위한 frontend 자동배포 파이프라인 작업입니다.

## ✅ 작업 내용

- [x] `.github/workflows/frontend-deploy.yml` 추가
- [x] `main` 브랜치 기준 frontend 변경 시에만 실행되도록 `paths` 조건 설정
- [x] GitHub Actions에서 Node 환경 구성 및 frontend `npm ci`, `npm run build` 설정
- [x] Vercel CLI를 통한 production 배포 자동화
- [x] `vercel.json` 추가 및 SPA 라우팅용 rewrite 설정 적용
- [x] frontend 자동배포 흐름 구성

---

## 🔗 관련 이슈

- Closes https://github.com/hhd1337/jatuli-quiz/issues/24