### PR TITLE
fix(frontend/ci): GitHub Actions Vercel 배포 경로 설정 수정

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -12,10 +12,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        working-directory: ./frontend
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,9 +24,11 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
+        working-directory: ./frontend
         run: npm ci
 
       - name: Build project
+        working-directory: ./frontend
         run: npm run build
 
       - name: Deploy to Vercel


### PR DESCRIPTION
## 📝 작업 내용 설명
Vercel 프로젝트의 Root Directory가 이미 frontend로 설정된 상태에서 
GitHub Actions도 frontend 디렉터리에서 deploy를 실행해 경로가 중복 적용되던 문제를 수정했다.

## ✅ 작업 내용
- [x] Vercel Root Directory와 GitHub Actions 실행 경로 중복 문제 수정

## 🔗 관련 이슈
- Closes https://github.com/hhd1337/jatuli-quiz/issues/24