### PR TITLE
feat(backend): HTTPS API 도메인 적용을 위한 CORS 설정 추가

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/WebConfig.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/WebConfig.java
@@ -11,7 +11,10 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins(
+                        "http://localhost:3000",
                         "http://localhost:5173",
+                        "https://jatuli.online",
+                        "https://www.jatuli.online",
                         "https://jatuli-quiz-frontend.vercel.app"
                 )
                 .allowedMethods("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS")


### PR DESCRIPTION
## 📝 작업 내용 설명

백엔드 HTTPS 및 API 도메인 적용 과정에서, 운영 프론트엔드와 로컬 개발 환경에서의 API 호출이 가능하도록 CORS 허용 origin을 추가했다.

기존에는 일부 origin만 허용되어 있어 도메인 분리 후 브라우저 환경에서 요청이 차단될 수 있었다.
이번 변경으로 로컬 개발 주소와 운영 프론트 도메인을 허용하여, 이후 `https://api.jatuli.online` 기반 API 연동이 가능하도록 기반을 마련했다.

## ✅ 작업 내용

* [x] 로컬 개발용 origin 추가

  * [x] `http://localhost:3000`
  * [x] `http://localhost:5173`
* [x] 운영 프론트 도메인 origin 추가

  * [x] `https://jatuli.online`
  * [x] `https://jatuli-quiz-frontend.vercel.app`
* [x] 허용 HTTP 메서드 범위 유지 및 점검
* [x] credentials 미사용 정책 유지 (`allowCredentials(false)`)


Closes #29
