### PR TITLE
fix(backend/folder): 폴더 하위 목록 조회 시 non-leaf 진행도 누적 집계 반영

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/FolderRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/FolderRestController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/folders")
+@RequestMapping("/api/v1/folders")
 @RequiredArgsConstructor
 public class FolderRestController {
     private final FolderQueryService folderQueryService;

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/converter/FolderConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/converter/FolderConverter.java
@@ -1,0 +1,75 @@
+package com.hhd1337.jatuli_quiz.domain.folder.converter;
+
+import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.FolderChildrenResponse;
+import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.PracticeProblemDto;
+import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.PracticeProblemMetaDto;
+import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.PracticeResponse;
+import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
+import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+import java.util.List;
+
+public class FolderConverter {
+
+    private FolderConverter() {
+    }
+
+    public static FolderChildrenResponse toFolderChildrenResponse(
+            List<FolderChildrenResponse.BreadcrumbDTO> breadcrumb,
+            List<FolderChildrenResponse.FolderDTO> folders
+    ) {
+        return FolderChildrenResponse.builder()
+                .breadcrumb(breadcrumb)
+                .folders(folders)
+                .build();
+    }
+
+    public static FolderChildrenResponse.BreadcrumbDTO toBreadcrumbDTO(Folder folder) {
+        return FolderChildrenResponse.BreadcrumbDTO.builder()
+                .folderId(folder.getFolderId())
+                .name(folder.getName())
+                .build();
+    }
+
+    public static FolderChildrenResponse.FolderDTO toFolderDTO(
+            Folder folder,
+            int solved,
+            int total,
+            boolean hasChildren
+    ) {
+        return FolderChildrenResponse.FolderDTO.builder()
+                .folderId(folder.getFolderId())
+                .name(folder.getName())
+                .solved(solved)
+                .total(total)
+                .hasChildren(hasChildren)
+                .build();
+    }
+
+    public static PracticeResponse toPracticeResponse(
+            String selectionRule,
+            List<PracticeProblemDto> problems
+    ) {
+        return PracticeResponse.builder()
+                .selectionRule(selectionRule)
+                .problems(problems)
+                .build();
+    }
+
+    public static PracticeProblemDto toPracticeProblemDto(Problem problem) {
+        return PracticeProblemDto.builder()
+                .problemId(problem.getProblemId())
+                .problemNum(problem.getProblemNum())
+                .question(problem.getQuestionText())
+                .answer(problem.getAnswerText())
+                .explanation(problem.getExplanationText())
+                .meta(toPracticeProblemMetaDto(problem))
+                .build();
+    }
+
+    public static PracticeProblemMetaDto toPracticeProblemMetaDto(Problem problem) {
+        return PracticeProblemMetaDto.builder()
+                .attemptCount(problem.getSolvedCount())
+                .isBookmarked(problem.getIsBookmarked())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderQueryServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderQueryServiceImpl.java
@@ -3,9 +3,9 @@ package com.hhd1337.jatuli_quiz.domain.folder.service;
 import com.hhd1337.jatuli_quiz.common.exception.GeneralException;
 import com.hhd1337.jatuli_quiz.common.exception.code.status.ErrorStatus;
 import com.hhd1337.jatuli_quiz.common.exception.handler.FolderHandler;
+import com.hhd1337.jatuli_quiz.domain.folder.converter.FolderConverter;
 import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.FolderChildrenResponse;
 import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.PracticeProblemDto;
-import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.PracticeProblemMetaDto;
 import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.PracticeResponse;
 import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
 import com.hhd1337.jatuli_quiz.domain.folder.repository.FolderRepository;
@@ -40,10 +40,7 @@ public class FolderQueryServiceImpl implements FolderQueryService {
                 .map(this::toFolderDTO)
                 .toList();
 
-        return FolderChildrenResponse.builder()
-                .breadcrumb(breadcrumb)
-                .folders(folders)
-                .build();
+        return FolderConverter.toFolderChildrenResponse(breadcrumb, folders);
     }
 
     private List<FolderChildrenResponse.BreadcrumbDTO> buildBreadcrumb(Folder currentFolder) {
@@ -51,11 +48,7 @@ public class FolderQueryServiceImpl implements FolderQueryService {
 
         Folder cursor = currentFolder;
         while (cursor != null) {
-            breadcrumb.add(0, FolderChildrenResponse.BreadcrumbDTO.builder()
-                    .folderId(cursor.getFolderId())
-                    .name(cursor.getName())
-                    .build());
-
+            breadcrumb.add(0, FolderConverter.toBreadcrumbDTO(cursor));
             cursor = cursor.getParentFolder();
         }
 
@@ -63,17 +56,30 @@ public class FolderQueryServiceImpl implements FolderQueryService {
     }
 
     private FolderChildrenResponse.FolderDTO toFolderDTO(Folder folder) {
+        boolean hasChildren = folderRepository.existsByParentFolder(folder);
+        FolderStats stats = calculateFolderStats(folder);
+
+        return FolderConverter.toFolderDTO(
+                folder,
+                stats.solved(),
+                stats.total(),
+                hasChildren
+        );
+    }
+
+    private FolderStats calculateFolderStats(Folder folder) {
         int total = problemRepository.countByFolder(folder);
         int solved = problemRepository.countByFolderAndSolvedCountGreaterThan(folder, 0);
-        boolean hasChildren = folderRepository.existsByParentFolder(folder);
 
-        return FolderChildrenResponse.FolderDTO.builder()
-                .folderId(folder.getFolderId())
-                .name(folder.getName())
-                .solved(solved)
-                .total(total)
-                .hasChildren(hasChildren)
-                .build();
+        List<Folder> children = folderRepository.findByParentFolder_FolderIdOrderByFolderIdAsc(folder.getFolderId());
+
+        for (Folder child : children) {
+            FolderStats childStats = calculateFolderStats(child);
+            total += childStats.total();
+            solved += childStats.solved();
+        }
+
+        return new FolderStats(total, solved);
     }
 
     @Override
@@ -89,28 +95,12 @@ public class FolderQueryServiceImpl implements FolderQueryService {
         List<Problem> problems = problemRepository.findAllByFolder_FolderIdOrderByProblemNumAsc(folderId);
 
         List<PracticeProblemDto> problemDtos = problems.stream()
-                .map(this::toPracticeProblemDto)
+                .map(FolderConverter::toPracticeProblemDto)
                 .toList();
 
-        return PracticeResponse.builder()
-                .selectionRule(SELECTION_RULE_ALL)
-                .problems(problemDtos)
-                .build();
+        return FolderConverter.toPracticeResponse(SELECTION_RULE_ALL, problemDtos);
     }
 
-    private PracticeProblemDto toPracticeProblemDto(Problem problem) {
-        return PracticeProblemDto.builder()
-                .problemId(problem.getProblemId())
-                .problemNum(problem.getProblemNum())
-                .question(problem.getQuestionText())
-                .answer(problem.getAnswerText())
-                .explanation(problem.getExplanationText())
-                .meta(
-                        PracticeProblemMetaDto.builder()
-                                .attemptCount(problem.getSolvedCount())
-                                .isBookmarked(problem.getIsBookmarked())
-                                .build()
-                )
-                .build();
+    private record FolderStats(int total, int solved) {
     }
 }


### PR DESCRIPTION
## 📝 작업 내용 설명

`/api/v1/folders/{folderId}/children` 조회 시 하위 폴더 목록의 `solved`, `total` 값을
직접 소속된 문제만 기준으로 계산하던 구조를 수정했다.

이제 leaf 폴더는 해당 폴더의 직접 문제 기준으로 진행도를 계산하고,
non-leaf 폴더는 하위 자손 폴더까지 재귀적으로 순회하여 solved/total을 누적 집계해 내려주도록 변경했다.

또한 DTO 생성 책임을 `FolderConverter`로 분리해
서비스 계층은 조회 흐름과 재귀 집계 로직에 집중하도록 정리했다.

## ✅ 작업할 내용
- [x] `FolderQueryServiceImpl`에서 하위 폴더 진행도 재귀 집계 로직 추가
- [x] leaf / non-leaf 폴더 공통 진행도 계산 방식 정리
- [x] breadcrumb 및 folder/practice DTO 생성 로직을 `FolderConverter`로 분리
- [x] `/api/v1/folders/{folderId}/children` 응답에 누적 solved/total 반영
- [x] 기존 practice 조회 로직의 DTO 변환도 converter 사용으로 정리

## 🔍 변경 포인트
- non-leaf 폴더도 서브트리 전체 기준 진행도 표시 가능
- 프론트 폴더 브라우저에서 `(푼 문제 수 / 전체 문제 수)`가 기대한 방식으로 표시됨
- 서비스/컨버터 책임 분리로 코드 가독성 개선

## 📌 비고
- 현재는 조회 시점마다 재귀적으로 하위 폴더를 순회하여 집계하는 방식이다.
- 폴더/문제 데이터가 매우 많아질 경우 추후 집계 쿼리 최적화 또는 캐시 전략을 고려할 수 있다.