### PR TITLE
feat(front/home): 홈 조회 API 연동 및 성취 카드 시간 표시 개선

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/HomeRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/HomeRestController.java
@@ -6,9 +6,11 @@ import com.hhd1337.jatuli_quiz.domain.home.service.HomeQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api/v1/home")
 @RequiredArgsConstructor
 public class HomeRestController {
 
@@ -23,7 +25,7 @@ public class HomeRestController {
                     루트 폴더 목록에는 ROOT 폴더의 직계 하위 폴더들과 각 폴더의 solved/total 문제가 포함됩니다.
                     """
     )
-    @GetMapping("/home")
+    @GetMapping
     public ApiResponse<HomeResponse.GetHomeResponse> getHome() {
         return ApiResponse.onSuccess(homeQueryService.getHome());
     }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/converter/HomeConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/converter/HomeConverter.java
@@ -2,6 +2,7 @@ package com.hhd1337.jatuli_quiz.domain.home.converter;
 
 import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
 import com.hhd1337.jatuli_quiz.domain.home.dto.HomeResponse;
+import java.util.List;
 
 public class HomeConverter {
 
@@ -9,14 +10,14 @@ public class HomeConverter {
     }
 
     public static HomeResponse.AchievementCard toAchievementCard(
-            Integer todayFocusSeconds,
-            Long accumulatedFocusSeconds,
-            Integer todaySolvedCount,
-            Integer totalSolvedCount,
-            Integer daysInARow,
-            Integer level,
-            Integer todayGoalCount,
-            Integer todayGoalSolvedCount
+            int todayFocusSeconds,
+            long accumulatedFocusSeconds,
+            int todaySolvedCount,
+            int totalSolvedCount,
+            int daysInARow,
+            int level,
+            int todayGoalCount,
+            int todayGoalSolvedCount
     ) {
         return HomeResponse.AchievementCard.builder()
                 .todayFocusSeconds(todayFocusSeconds)
@@ -32,19 +33,20 @@ public class HomeConverter {
 
     public static HomeResponse.RootFolderItem toRootFolderItem(
             Folder folder,
-            Integer solvedProblemCount
+            int solvedProblemCount,
+            int totalProblemCount
     ) {
         return HomeResponse.RootFolderItem.builder()
                 .folderId(folder.getFolderId())
                 .name(folder.getName())
                 .solvedProblemCount(solvedProblemCount)
-                .totalProblemCount(folder.getProblemCount() == null ? 0 : folder.getProblemCount())
+                .totalProblemCount(totalProblemCount)
                 .build();
     }
 
     public static HomeResponse.GetHomeResponse toGetHomeResponse(
             HomeResponse.AchievementCard achievementCard,
-            java.util.List<HomeResponse.RootFolderItem> rootFolders
+            List<HomeResponse.RootFolderItem> rootFolders
     ) {
         return HomeResponse.GetHomeResponse.builder()
                 .achievementCard(achievementCard)

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/service/HomeQueryServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/service/HomeQueryServiceImpl.java
@@ -68,16 +68,35 @@ public class HomeQueryServiceImpl implements HomeQueryService {
         List<Folder> rootFolders = folderRepository.findAllByParentFolder_FolderIdOrderByFolderIdAsc(ROOT_FOLDER_ID);
 
         List<HomeResponse.RootFolderItem> rootFolderItems = rootFolders.stream()
-                .map(folder -> {
-                    Integer solvedProblemCount = problemRepository.countSolvedProblemsByFolderId(folder.getFolderId());
-                    if (solvedProblemCount == null) {
-                        solvedProblemCount = 0;
-                    }
-                    return HomeConverter.toRootFolderItem(folder, solvedProblemCount);
-                })
+                .map(this::toRootFolderItem)
                 .toList();
 
         return HomeConverter.toGetHomeResponse(achievementCard, rootFolderItems);
+    }
+
+    private HomeResponse.RootFolderItem toRootFolderItem(Folder folder) {
+        FolderStats stats = calculateFolderStats(folder);
+
+        return HomeConverter.toRootFolderItem(
+                folder,
+                stats.solved(),
+                stats.total()
+        );
+    }
+
+    private FolderStats calculateFolderStats(Folder folder) {
+        int total = problemRepository.countByFolder(folder);
+        int solved = problemRepository.countByFolderAndSolvedCountGreaterThan(folder, 0);
+
+        List<Folder> children = folderRepository.findAllByParentFolder_FolderIdOrderByFolderIdAsc(folder.getFolderId());
+
+        for (Folder child : children) {
+            FolderStats childStats = calculateFolderStats(child);
+            total += childStats.total();
+            solved += childStats.solved();
+        }
+
+        return new FolderStats(total, solved);
     }
 
     private int calculateLevel(int totalSolvedCount) {
@@ -94,5 +113,8 @@ public class HomeQueryServiceImpl implements HomeQueryService {
             return 2;
         }
         return 1;
+    }
+
+    private record FolderStats(int total, int solved) {
     }
 }

--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -68,14 +68,18 @@ export default function HomePage() {
                     borderRadius: 12,
                     padding: 16,
                     marginBottom: 24,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 8,
                 }}
             >
-                <div>⏳ 자투리 시간 저축 {summary.savedTimeMinutes}분</div>
+                <div>⏳ 누적 자투리시간 저축: {summary.accumulatedFocusTimeText}</div>
+                <div>📚 누적 푼 문제 수: {summary.solvedCountTotal}문제</div>
+                <div>🕒 오늘 자투리 시간 저축: {summary.todayFocusTimeText}</div>
+                <div>✅ 오늘 푼 문제 수: {summary.todaySolvedCount}문제</div>
                 <div>🌱 Level {summary.level} ({summary.solvedCountTotal}문제 해결)</div>
                 <div>🔥 {summary.streakDays}일 연속 도전 중</div>
-                <div style={{ marginTop: 8 }}>
-                    🎯 오늘 목표 {summary.todayGoal.solvedCount}/{summary.todayGoal.goalCount}
-                </div>
+                <div>🎯 오늘 목표 {summary.todayGoal.solvedCount}/{summary.todayGoal.goalCount}</div>
             </div>
 
             {/* ================== 폴더 리스트 ================== */}

--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -1,66 +1,137 @@
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { homeMock } from "../../mocks/home.mock";
+import { getHomeData } from "../../shared/api/homeApi";
 
 export default function HomePage() {
-  const navigate = useNavigate();
-  const { summary, rootFolders, quickActions } = homeMock;
+    const navigate = useNavigate();
 
-  return (
-    <div style={{ maxWidth: 800, margin: "0 auto" }}>
-      <h1>자투리 퀴즈 홈</h1>
+    const [homeData, setHomeData] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
 
-      {/* ================== 성취 카드 ================== */}
-      <div
-        style={{
-          border: "1px solid #ddd",
-          borderRadius: 12,
-          padding: 16,
-          marginBottom: 24,
-        }}
-      >
-        <div>⏳ 자투리 시간 저축 {summary.savedTimeMinutes}분</div>
-        <div>🌱 Level {summary.level} ({summary.solvedCountTotal}문제 해결)</div>
-        <div>🔥 {summary.streakDays}일 연속 도전 중</div>
-        <div style={{ marginTop: 8 }}>
-          🎯 오늘 목표 {summary.todayGoal.solvedCount}/{summary.todayGoal.goalCount}
+    useEffect(() => {
+        async function fetchHomeData() {
+            try {
+                setLoading(true);
+                setError("");
+
+                const data = await getHomeData();
+                setHomeData(data);
+            } catch (err) {
+                console.error("홈 화면 조회 실패:", err);
+                setError("홈 화면 정보를 불러오지 못했습니다.");
+            } finally {
+                setLoading(false);
+            }
+        }
+
+        fetchHomeData();
+    }, []);
+
+    if (loading) {
+        return (
+            <div style={{ maxWidth: 800, margin: "0 auto" }}>
+                <h1>자투리 퀴즈 홈</h1>
+                <p>불러오는 중...</p>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div style={{ maxWidth: 800, margin: "0 auto" }}>
+                <h1>자투리 퀴즈 홈</h1>
+                <p>{error}</p>
+            </div>
+        );
+    }
+
+    if (!homeData) {
+        return (
+            <div style={{ maxWidth: 800, margin: "0 auto" }}>
+                <h1>자투리 퀴즈 홈</h1>
+                <p>홈 데이터가 없습니다.</p>
+            </div>
+        );
+    }
+
+    const { summary, rootFolders, quickActions } = homeData;
+
+    return (
+        <div style={{ maxWidth: 800, margin: "0 auto" }}>
+            <h1>자투리 퀴즈 홈</h1>
+
+            {/* ================== 성취 카드 ================== */}
+            <div
+                style={{
+                    border: "1px solid #ddd",
+                    borderRadius: 12,
+                    padding: 16,
+                    marginBottom: 24,
+                }}
+            >
+                <div>⏳ 자투리 시간 저축 {summary.savedTimeMinutes}분</div>
+                <div>🌱 Level {summary.level} ({summary.solvedCountTotal}문제 해결)</div>
+                <div>🔥 {summary.streakDays}일 연속 도전 중</div>
+                <div style={{ marginTop: 8 }}>
+                    🎯 오늘 목표 {summary.todayGoal.solvedCount}/{summary.todayGoal.goalCount}
+                </div>
+            </div>
+
+            {/* ================== 폴더 리스트 ================== */}
+            <h2>카테고리</h2>
+
+            {rootFolders.length === 0 ? (
+                <p>표시할 카테고리가 없습니다.</p>
+            ) : (
+                <ul style={{ listStyle: "none", padding: 0 }}>
+                    {rootFolders.map((folder) => (
+                        <li
+                            key={folder.folderId}
+                            onClick={() => navigate(`/folders/${folder.folderId}`)}
+                            style={{
+                                padding: 12,
+                                borderBottom: "1px solid #eee",
+                                cursor: "pointer",
+                            }}
+                        >
+                            📁 {folder.name} ({folder.solvedCount}/{folder.totalCount})
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {/* ================== 빠른 실행 ================== */}
+            <div style={{ marginTop: 32 }}>
+                <h2>빠른 실행</h2>
+
+                {quickActions.map((action) => {
+                    if (action.key === "RANDOM") {
+                        return (
+                            <button
+                                key={action.key}
+                                onClick={() => navigate("/quiz/play?mode=random")}
+                                style={{ marginRight: 8 }}
+                            >
+                                🎲 {action.label}
+                            </button>
+                        );
+                    }
+
+                    if (action.key === "BOOKMARK") {
+                        return (
+                            <button
+                                key={action.key}
+                                onClick={() => navigate("/quiz/play?mode=bookmark")}
+                            >
+                                📦 {action.label}
+                            </button>
+                        );
+                    }
+
+                    return null;
+                })}
+            </div>
         </div>
-      </div>
-
-      {/* ================== 폴더 리스트 ================== */}
-      <h2>카테고리</h2>
-      <ul style={{ listStyle: "none", padding: 0 }}>
-        {rootFolders.map((folder) => (
-          <li
-            key={folder.folderId}
-            onClick={() => navigate(`/folders/${folder.folderId}`)}
-            style={{
-              padding: 12,
-              borderBottom: "1px solid #eee",
-              cursor: "pointer",
-            }}
-          >
-            📁 {folder.name} ({folder.solvedCount}/{folder.totalCount})
-          </li>
-        ))}
-      </ul>
-
-      {/* ================== 빠른 실행 ================== */}
-      <div style={{ marginTop: 32 }}>
-        <h2>빠른 실행</h2>
-
-        <button
-          onClick={() => navigate("/quiz/play?mode=random")}
-          style={{ marginRight: 8 }}
-        >
-          🎲 랜덤 문제 풀기
-        </button>
-
-        <button
-          onClick={() => navigate("/quiz/play?mode=bookmark")}
-        >
-          📦 북마크 문제 풀기
-        </button>
-      </div>
-    </div>
-  );
+    );
 }

--- a/frontend/src/shared/api/homeApi.js
+++ b/frontend/src/shared/api/homeApi.js
@@ -1,14 +1,42 @@
 import { apiClient } from "./client";
 
+function formatSecondsToKoreanTime(totalSeconds) {
+    const safeSeconds = Math.max(0, Number(totalSeconds) || 0);
+
+    const hours = Math.floor(safeSeconds / 3600);
+    const minutes = Math.floor((safeSeconds % 3600) / 60);
+    const seconds = safeSeconds % 60;
+
+    const parts = [];
+
+    if (hours > 0) {
+        parts.push(`${hours}시간`);
+    }
+    if (minutes > 0) {
+        parts.push(`${minutes}분`);
+    }
+    if (seconds > 0 || parts.length === 0) {
+        parts.push(`${seconds}초`);
+    }
+
+    return parts.join(" ");
+}
+
 function normalizeHomeResponse(raw) {
     const achievementCard = raw?.achievementCard ?? {};
     const rootFolders = Array.isArray(raw?.rootFolders) ? raw.rootFolders : [];
 
     return {
         summary: {
-            savedTimeMinutes: Math.floor((achievementCard.accumulatedFocusSeconds ?? 0) / 60),
+            accumulatedFocusTimeText: formatSecondsToKoreanTime(
+                achievementCard.accumulatedFocusSeconds
+            ),
+            todayFocusTimeText: formatSecondsToKoreanTime(
+                achievementCard.todayFocusSeconds
+            ),
             level: achievementCard.level ?? 1,
             solvedCountTotal: achievementCard.totalSolvedCount ?? 0,
+            todaySolvedCount: achievementCard.todaySolvedCount ?? 0,
             streakDays: achievementCard.daysInARow ?? 0,
             todayGoal: {
                 goalCount: achievementCard.todayGoalCount ?? 10,

--- a/frontend/src/shared/api/homeApi.js
+++ b/frontend/src/shared/api/homeApi.js
@@ -1,0 +1,34 @@
+import { apiClient } from "./client";
+
+function normalizeHomeResponse(raw) {
+    const achievementCard = raw?.achievementCard ?? {};
+    const rootFolders = Array.isArray(raw?.rootFolders) ? raw.rootFolders : [];
+
+    return {
+        summary: {
+            savedTimeMinutes: Math.floor((achievementCard.accumulatedFocusSeconds ?? 0) / 60),
+            level: achievementCard.level ?? 1,
+            solvedCountTotal: achievementCard.totalSolvedCount ?? 0,
+            streakDays: achievementCard.daysInARow ?? 0,
+            todayGoal: {
+                goalCount: achievementCard.todayGoalCount ?? 10,
+                solvedCount: achievementCard.todayGoalSolvedCount ?? 0,
+            },
+        },
+        rootFolders: rootFolders.map((folder) => ({
+            folderId: folder.folderId,
+            name: folder.name ?? "",
+            solvedCount: folder.solvedProblemCount ?? 0,
+            totalCount: folder.totalProblemCount ?? 0,
+        })),
+        quickActions: [
+            { key: "RANDOM", label: "랜덤 문제 풀기" },
+            { key: "BOOKMARK", label: "북마크 문제 풀기" },
+        ],
+    };
+}
+
+export async function getHomeData() {
+    const response = await apiClient.get("/api/v1/home");
+    return normalizeHomeResponse(response.data.result);
+}


### PR DESCRIPTION
## 📝 작업 내용 설명

프론트엔드 홈 화면을 목데이터 기반에서 실제 backend API 연동 방식으로 전환했다.

기존 `HomePage`는 `home.mock.js`를 사용해 성취 카드, 카테고리 목록, 빠른 실행 영역을 렌더링하고 있었는데,
이번 작업에서는 `homeApi.js`를 통해 backend의 홈 화면 조회 API를 호출하도록 변경했다.

또한 backend 응답의 `achievementCard`, `rootFolders`를 프론트 UI 구조에 맞게 매핑하는 정규화 로직을 추가했고,
로딩/에러/빈 응답 상태도 함께 처리하여 실제 환경에서 안정적으로 동작하도록 정리했다.

추가로 성취 카드에서 `todayFocusSeconds`, `accumulatedFocusSeconds`는 초 단위 값을 그대로 쓰지 않고,
시/분/초 형태의 보기 좋은 문자열로 가공해 표시하도록 변경했다.

## ✅ 작업할 내용
- [x] `homeApi.js`에 홈 조회 API 호출 함수 구현
- [x] `HomePage.jsx`에서 `home.mock.js` 제거
- [x] backend 홈 조회 API 응답 구조에 맞게 데이터 매핑 로직 추가
- [x] 성취 카드 영역을 실제 응답 기반으로 전환
- [x] 카테고리 목록을 실제 `rootFolders` 기반으로 전환
- [x] 빠른 실행 버튼 유지
- [x] API 호출 중 로딩 상태 처리
- [x] API 호출 실패 시 에러 상태 처리
- [x] 빈 응답 또는 `rootFolders`가 비어 있는 경우 처리
- [x] 초 단위 시간 값을 시/분/초 문자열로 가공하는 로직 추가
- [x] 성취 카드 UI를 요구사항에 맞게 재구성
- [x] 로컬 환경에서 홈 조회 API 연동 확인

## 🔍 변경 포인트
- 홈 화면이 더 이상 mock 데이터에 의존하지 않음
- backend 응답을 프론트 UI 구조에 맞게 정규화하여 사용
- 성취 카드가 실데이터 기반으로 렌더링됨
- 누적/오늘 자투리 시간 저축을 시/분/초 형태로 표시
- 누적 푼 문제 수 / 오늘 푼 문제 수를 카드에 명확히 표시
- 카테고리 목록이 실제 root folder 데이터 기반으로 표시됨
- 로딩/에러/빈 응답 상태가 추가되어 운영 안정성 개선

## 📌 비고
- 운영 환경 확인은 배포 후 최종 점검 예정
- 랜덤 문제 풀기 / 북마크 문제 풀기 버튼의 실제 API 연동은 별도 이슈에서 진행 예정