### PR TITLE
feat(backend/problem): 문제 문자열 형태로 일괄 등록하기 API 구

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
@@ -21,7 +21,9 @@ public enum ErrorStatus implements BaseErrorCode {
     FOLDER_NOT_LEAF(HttpStatus.BAD_REQUEST, "FOLDER4001", "연습 문제 조회는 leaf 폴더에서만 가능합니다."),
 
     // 문제 관련 에러
-    PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROBLEM4041", "존재하지 않는 문제입니다.");
+    PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROBLEM4041", "존재하지 않는 문제입니다."),
+    PROBLEM_TEXT_PARSE_FAILED(HttpStatus.BAD_REQUEST, "PROBLEM4001", "문제 문자열 파싱에 실패했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "PROBLEM4002", "잘못된 문제 입력입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/entity/Folder.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/entity/Folder.java
@@ -53,4 +53,11 @@ public class Folder {
         this.problemCount = problemCount;
         this.parentFolder = parentFolder;
     }
+
+    public void increaseProblemCount(int count) {
+        if (this.problemCount == null) {
+            this.problemCount = 0;
+        }
+        this.problemCount += count;
+    }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
@@ -2,12 +2,16 @@ package com.hhd1337.jatuli_quiz.domain.problem;
 
 import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportRequest;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.service.ProblemCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,4 +36,43 @@ public class ProblemRestController {
     ) {
         return ApiResponse.onSuccess(problemCommandService.toggleBookmark(problemId));
     }
+
+    @Operation(
+            summary = "문제 문자열 일괄 등록",
+            description = """
+                    GPT가 생성한 문제 문자열을 받아 problem 테이블에 일괄 저장합니다.
+                    요청 본문에는 folderId와 rawText를 포함해야 합니다.
+                    rawText는 다음 포맷을 따릅니다.
+                    
+                    ### 문제 1
+                    문제 본문
+                    
+                    해설
+                    해설 본문
+                    
+                    정답
+                    정답 본문
+                    
+                    ---
+                    
+                    여러 문제가 위 형식으로 반복되면 모두 파싱하여 저장합니다.
+                    저장 시 problem_num은 해당 폴더 내 마지막 문제 번호 다음 번호부터 순차 부여합니다.
+                    """
+    )
+    @PostMapping(value = "/import/text", consumes = "text/plain")
+    public ApiResponse<ProblemImportResponse.ImportProblemsFromTextResponse> importProblemsFromText(
+            @RequestParam Long folderId,
+            @RequestBody String rawText
+    ) {
+        ProblemImportRequest.ImportProblemsFromTextRequest request =
+                new ProblemImportRequest.ImportProblemsFromTextRequest(folderId, rawText);
+
+        return ApiResponse.onSuccess(problemCommandService.importProblemsFromText(request));
+    }
+//    @PostMapping("/import/text")
+//    public ApiResponse<ProblemImportResponse.ImportProblemsFromTextResponse> importProblemsFromText(
+//            @Valid @RequestBody ProblemImportRequest.ImportProblemsFromTextRequest request
+//    ) {
+//        return ApiResponse.onSuccess(problemCommandService.importProblemsFromText(request));
+//    }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
@@ -69,10 +69,4 @@ public class ProblemRestController {
 
         return ApiResponse.onSuccess(problemCommandService.importProblemsFromText(request));
     }
-//    @PostMapping("/import/text")
-//    public ApiResponse<ProblemImportResponse.ImportProblemsFromTextResponse> importProblemsFromText(
-//            @Valid @RequestBody ProblemImportRequest.ImportProblemsFromTextRequest request
-//    ) {
-//        return ApiResponse.onSuccess(problemCommandService.importProblemsFromText(request));
-//    }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/converter/ProblemConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/converter/ProblemConverter.java
@@ -1,7 +1,9 @@
 package com.hhd1337.jatuli_quiz.domain.problem.converter;
 
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+import java.util.List;
 
 public class ProblemConverter {
 
@@ -12,6 +14,27 @@ public class ProblemConverter {
         return ProblemBookmarkResponse.ToggleBookmarkResponse.builder()
                 .problemId(problem.getProblemId())
                 .isBookmarked(problem.getIsBookmarked())
+                .build();
+    }
+
+    public static ProblemImportResponse.ImportedProblemItem toImportedProblemItem(Problem problem) {
+        return ProblemImportResponse.ImportedProblemItem.builder()
+                .problemId(problem.getProblemId())
+                .problemNum(problem.getProblemNum())
+                .questionText(problem.getQuestionText())
+                .build();
+    }
+
+    public static ProblemImportResponse.ImportProblemsFromTextResponse toImportProblemsFromTextResponse(
+            Long folderId,
+            List<Problem> savedProblems
+    ) {
+        return ProblemImportResponse.ImportProblemsFromTextResponse.builder()
+                .folderId(folderId)
+                .savedCount(savedProblems.size())
+                .problems(savedProblems.stream()
+                        .map(ProblemConverter::toImportedProblemItem)
+                        .toList())
                 .build();
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ParsedProblemContent.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ParsedProblemContent.java
@@ -1,0 +1,15 @@
+package com.hhd1337.jatuli_quiz.domain.problem.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ParsedProblemContent {
+    private Integer originalProblemNum;
+    private String questionText;
+    private String explanationText;
+    private String answerText;
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ProblemImportRequest.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ProblemImportRequest.java
@@ -1,0 +1,25 @@
+package com.hhd1337.jatuli_quiz.domain.problem.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ProblemImportRequest {
+    //    @Getter
+//    @NoArgsConstructor
+//    public static class ImportProblemsFromTextRequest {
+//
+//        @NotNull
+//        private Long folderId;
+//
+//        @NotBlank
+//        private String rawText;
+//    }
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ImportProblemsFromTextRequest {
+        private Long folderId;
+        private String rawText;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ProblemImportResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ProblemImportResponse.java
@@ -1,0 +1,27 @@
+package com.hhd1337.jatuli_quiz.domain.problem.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ProblemImportResponse {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ImportProblemsFromTextResponse {
+        private Long folderId;
+        private Integer savedCount;
+        private List<ImportedProblemItem> problems;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ImportedProblemItem {
+        private Long problemId;
+        private Integer problemNum;
+        private String questionText;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/entity/Problem.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/entity/Problem.java
@@ -69,6 +69,24 @@ public class Problem {
         this.folder = folder;
     }
 
+    public static Problem of(
+            Integer problemNum,
+            String questionText,
+            String explanationText,
+            String answerText,
+            Folder folder
+    ) {
+        return new Problem(
+                problemNum,
+                questionText,
+                explanationText,
+                answerText,
+                false,
+                0,
+                folder
+        );
+    }
+
     public void increaseSolvedCount() {
         if (this.solvedCount == null) {
             this.solvedCount = 0;

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
@@ -3,6 +3,7 @@ package com.hhd1337.jatuli_quiz.domain.problem.repository;
 import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
 import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -23,7 +24,7 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
                   and p.solvedCount > 0
             """)
     Integer countSolvedProblemsByFolderId(Long folderId);
-    
+
     @Query("""
             select p
             from Problem p
@@ -31,4 +32,7 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
             order by coalesce(p.solvedCount, 0) asc, p.problemId asc
             """)
     List<Problem> findBookmarkedProblemsOrderByAttemptCountAsc();
+
+    Optional<Problem> findTopByFolder_FolderIdOrderByProblemNumDesc(Long folderId);
+
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandService.java
@@ -1,8 +1,14 @@
 package com.hhd1337.jatuli_quiz.domain.problem.service;
 
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportRequest;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportResponse;
 
 public interface ProblemCommandService {
 
     ProblemBookmarkResponse.ToggleBookmarkResponse toggleBookmark(Long problemId);
+
+    ProblemImportResponse.ImportProblemsFromTextResponse importProblemsFromText(
+            ProblemImportRequest.ImportProblemsFromTextRequest request
+    );
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
@@ -2,10 +2,17 @@ package com.hhd1337.jatuli_quiz.domain.problem.service;
 
 import com.hhd1337.jatuli_quiz.common.exception.GeneralException;
 import com.hhd1337.jatuli_quiz.common.exception.code.status.ErrorStatus;
+import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
+import com.hhd1337.jatuli_quiz.domain.folder.repository.FolderRepository;
 import com.hhd1337.jatuli_quiz.domain.problem.converter.ProblemConverter;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ParsedProblemContent;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportRequest;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
 import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProblemCommandServiceImpl implements ProblemCommandService {
 
     private final ProblemRepository problemRepository;
+    private final FolderRepository folderRepository;
+    private final ProblemTextParser problemTextParser;
 
     @Override
     public ProblemBookmarkResponse.ToggleBookmarkResponse toggleBookmark(Long problemId) {
@@ -25,5 +34,42 @@ public class ProblemCommandServiceImpl implements ProblemCommandService {
         problem.toggleBookmark();
 
         return ProblemConverter.toToggleBookmarkResponse(problem);
+    }
+
+    @Override
+    public ProblemImportResponse.ImportProblemsFromTextResponse importProblemsFromText(
+            ProblemImportRequest.ImportProblemsFromTextRequest request
+    ) {
+        Folder folder = folderRepository.findById(request.getFolderId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.FOLDER_NOT_FOUND));
+
+        List<ParsedProblemContent> parsedProblems = problemTextParser.parse(request.getRawText());
+
+        int startProblemNum = getNextProblemNum(folder.getFolderId());
+
+        List<Problem> problemsToSave = new ArrayList<>();
+        for (int i = 0; i < parsedProblems.size(); i++) {
+            ParsedProblemContent parsed = parsedProblems.get(i);
+
+            Problem problem = Problem.of(
+                    startProblemNum + i,
+                    parsed.getQuestionText(),
+                    parsed.getExplanationText(),
+                    parsed.getAnswerText(),
+                    folder
+            );
+            problemsToSave.add(problem);
+        }
+
+        List<Problem> savedProblems = problemRepository.saveAll(problemsToSave);
+        folder.increaseProblemCount(savedProblems.size());
+
+        return ProblemConverter.toImportProblemsFromTextResponse(folder.getFolderId(), savedProblems);
+    }
+
+    private int getNextProblemNum(Long folderId) {
+        return problemRepository.findTopByFolder_FolderIdOrderByProblemNumDesc(folderId)
+                .map(problem -> problem.getProblemNum() + 1)
+                .orElse(1);
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemTextParser.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemTextParser.java
@@ -1,0 +1,83 @@
+package com.hhd1337.jatuli_quiz.domain.problem.service;
+
+import com.hhd1337.jatuli_quiz.common.exception.GeneralException;
+import com.hhd1337.jatuli_quiz.common.exception.code.status.ErrorStatus;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ParsedProblemContent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProblemTextParser {
+
+    /**
+     * 지원 포맷 예시 ### 문제 1 질문...
+     * <p>
+     * 해설 설명...
+     * <p>
+     * 정답 답...
+     * <p>
+     * ---
+     */
+    private static final Pattern PROBLEM_BLOCK_PATTERN = Pattern.compile(
+            "###\\s*문제\\s*(\\d+)\\s*\\R" +          // 문제 번호
+                    "(.*?)\\R+해설\\s*\\R" +                 // 질문 본문
+                    "(.*?)\\R+정답\\s*\\R" +                 // 해설 본문
+                    "(.*?)(?=\\R+---\\R*|\\z)",              // 정답 본문
+            Pattern.DOTALL
+    );
+
+    public List<ParsedProblemContent> parse(String rawText) {
+        if (rawText == null || rawText.isBlank()) {
+            throw new GeneralException(ErrorStatus.INVALID_INPUT_VALUE);
+        }
+
+        String normalized = normalize(rawText);
+        Matcher matcher = PROBLEM_BLOCK_PATTERN.matcher(normalized);
+
+        List<ParsedProblemContent> results = new ArrayList<>();
+
+        while (matcher.find()) {
+            Integer originalProblemNum = Integer.parseInt(matcher.group(1).trim());
+            String questionText = clean(matcher.group(2));
+            String explanationText = clean(matcher.group(3));
+            String answerText = clean(matcher.group(4));
+
+            validateBlock(questionText, explanationText, answerText);
+
+            results.add(ParsedProblemContent.builder()
+                    .originalProblemNum(originalProblemNum)
+                    .questionText(questionText)
+                    .explanationText(explanationText)
+                    .answerText(answerText)
+                    .build());
+        }
+
+        if (results.isEmpty()) {
+            throw new GeneralException(ErrorStatus.PROBLEM_TEXT_PARSE_FAILED);
+        }
+
+        return results;
+    }
+
+    private String normalize(String rawText) {
+        return rawText.replace("\r\n", "\n")
+                .replace("\r", "\n")
+                .trim();
+    }
+
+    private String clean(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.trim();
+    }
+
+    private void validateBlock(String questionText, String explanationText, String answerText) {
+        if (questionText.isBlank() || explanationText.isBlank() || answerText.isBlank()) {
+            throw new GeneralException(ErrorStatus.PROBLEM_TEXT_PARSE_FAILED);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용 설명

문제를 문자열 형태로 받아 서버에서 파싱한 뒤, 지정한 폴더에 여러 문제를 한 번에 등록하는 API를 구현했다.

기존 문제 관련 작업 범위는 생성/조회/수정 전반을 포함하고 있었지만,
이번 PR에서는 우선 문자열 기반 일괄 등록 기능에 집중하여 백엔드 업로드 흐름을 먼저 완성했다.

프론트에서 전달한 원시 문자열을 서버에서 파싱하여 문제/정답/해설 단위로 분리하고,
이를 Problem 엔티티로 변환한 뒤 DB에 일괄 저장할 수 있도록 구성했다.

## ✅ 작업 내용
- [x] 문제 문자열 형태 일괄 등록 API 구현
- [x] 문자열 파싱 로직 구현
- [x] 파싱 결과를 Problem 엔티티 목록으로 변환
- [x] folderId 유효성 검사
- [x] 여러 문제 일괄 저장 처리
- [x] 요청 DTO validation 적용
- [x] 잘못된 문자열 형식 예외 처리
- [x] 존재하지 않는 폴더 예외 처리
- [x] Swagger 명세 반영

## 🔍 변경 포인트
- 문제를 하나씩 등록하지 않고 문자열 기반으로 한 번에 업로드 가능
- 프론트의 업로드 흐름을 실제 DB 저장 구조와 연결할 수 있는 기반 마련
- 잘못된 포맷, 잘못된 폴더 지정 등 예외 상황에 대한 처리 추가

## 📌 비고
- 문제 상세 조회 / 수정 API는 후속 작업으로 분리하여 진행 예정
- 프론트 업로드 화면과의 연동은 별도 PR 또는 후속 커밋에서 이어서 진행 예정