### PR TITLE
feat(frontend/quiz): 폴더 연습문제 조회 API 연동 및 퀴즈 플레이 사용성 개선

### DIFF
--- a/frontend/src/pages/folders/FolderBrowserPage.jsx
+++ b/frontend/src/pages/folders/FolderBrowserPage.jsx
@@ -29,8 +29,17 @@ export default function FolderBrowserPage() {
     }, [folderId]);
 
     const handleChildClick = (child) => {
+        if (!folderData) return;
+
+        const childTitlePath = `${folderData.titlePath}/${child.name}`.replace(/\/+/g, "/");
+
         if (child.isLeaf) {
-            navigate(`/quiz/play?folderId=${child.folderId}`);
+            navigate(`/quiz/play?folderId=${child.folderId}`, {
+                state: {
+                    titlePath: childTitlePath,
+                    parentFolderId: folderId,
+                },
+            });
             return;
         }
 

--- a/frontend/src/pages/quiz/QuizPlayPage.jsx
+++ b/frontend/src/pages/quiz/QuizPlayPage.jsx
@@ -1,20 +1,25 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { getFolderPractice } from "../../shared/api/folderApi";
 import FabGroup from "../../features/fab/FabGroup";
 
 export default function QuizPlayPage() {
     const navigate = useNavigate();
+    const location = useLocation();
     const [searchParams] = useSearchParams();
 
     const folderId = searchParams.get("folderId");
     const mode = searchParams.get("mode");
 
+    const initialTitlePath = location.state?.titlePath ?? "";
+    const parentFolderId = location.state?.parentFolderId ?? null;
+
     const [isMusicOn, setIsMusicOn] = useState(false);
     const [localProblems, setLocalProblems] = useState([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState("");
-    const [titlePath, setTitlePath] = useState("");
+    const [titlePath, setTitlePath] = useState(initialTitlePath);
+    const [showCompleteScreen, setShowCompleteScreen] = useState(false);
 
     const [currentIndex, setCurrentIndex] = useState(0);
     const [showAnswer, setShowAnswer] = useState(false);
@@ -28,17 +33,21 @@ export default function QuizPlayPage() {
             try {
                 setLoading(true);
                 setError("");
+                setShowCompleteScreen(false);
 
                 const data = await getFolderPractice(folderId);
                 setLocalProblems(data.problems ?? []);
-                setTitlePath(data.titlePath ?? "");
+
+                if (data.titlePath) {
+                    setTitlePath(data.titlePath);
+                }
+
                 setCurrentIndex(0);
                 setShowAnswer(false);
             } catch (err) {
                 console.error("연습 문제 조회 실패:", err);
                 setError("문제 목록을 불러오지 못했습니다.");
                 setLocalProblems([]);
-                setTitlePath("");
             } finally {
                 setLoading(false);
             }
@@ -46,6 +55,15 @@ export default function QuizPlayPage() {
 
         fetchPracticeProblems();
     }, [folderId]);
+
+    const handleExitFolder = () => {
+        if (parentFolderId) {
+            navigate(`/folders/${parentFolderId}`);
+            return;
+        }
+
+        navigate(-1);
+    };
 
     if (!folderId) {
         return (
@@ -81,7 +99,7 @@ export default function QuizPlayPage() {
             <div style={{ maxWidth: 800, margin: "0 auto" }}>
                 <h1 style={{ margin: 0 }}>{titlePath || `폴더 ${folderId}`}</h1>
                 <p>{error}</p>
-                <button onClick={() => navigate(-1)}>뒤로</button>
+                <button onClick={handleExitFolder}>폴더 나가기</button>
             </div>
         );
     }
@@ -91,7 +109,32 @@ export default function QuizPlayPage() {
             <div style={{ maxWidth: 800, margin: "0 auto" }}>
                 <h1 style={{ margin: 0 }}>{titlePath || `폴더 ${folderId}`}</h1>
                 <p>이 폴더에는 문제가 없습니다.</p>
-                <button onClick={() => navigate(-1)}>뒤로</button>
+                <button onClick={handleExitFolder}>폴더 나가기</button>
+            </div>
+        );
+    }
+
+    if (showCompleteScreen) {
+        return (
+            <div
+                style={{
+                    maxWidth: 800,
+                    margin: "0 auto",
+                    minHeight: "60vh",
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "center",
+                    alignItems: "center",
+                    textAlign: "center",
+                    gap: 16,
+                }}
+            >
+                <div style={{ fontSize: 64 }}>🎉</div>
+                <h1 style={{ margin: 0 }}>모두 풀었습니다!</h1>
+                <p style={{ opacity: 0.8 }}>
+                    이 폴더의 문제를 끝까지 모두 확인했어요.
+                </p>
+                <button onClick={handleExitFolder}>폴더 목록으로 돌아가기</button>
             </div>
         );
     }
@@ -102,12 +145,23 @@ export default function QuizPlayPage() {
         const next = currentIndex + 1;
 
         if (next >= problems.length) {
-            setCurrentIndex(0);
             setShowAnswer(false);
+            setShowCompleteScreen(true);
             return;
         }
 
         setCurrentIndex(next);
+        setShowAnswer(false);
+    };
+
+    const goPrev = () => {
+        const prev = currentIndex - 1;
+
+        if (prev < 0) {
+            return;
+        }
+
+        setCurrentIndex(prev);
         setShowAnswer(false);
     };
 
@@ -171,12 +225,15 @@ export default function QuizPlayPage() {
                 </div>
             )}
 
-            <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+            <div style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" }}>
                 <button onClick={() => setShowAnswer((v) => !v)}>
                     {showAnswer ? "정답/해설 숨기기" : "정답/해설 보기"}
                 </button>
+                <button onClick={goPrev} disabled={currentIndex === 0}>
+                    이전 문제
+                </button>
                 <button onClick={goNext}>다음 문제</button>
-                <button onClick={() => navigate(-1)}>뒤로</button>
+                <button onClick={handleExitFolder}>폴더 나가기</button>
             </div>
 
             {showAnswer && (

--- a/frontend/src/pages/quiz/QuizPlayPage.jsx
+++ b/frontend/src/pages/quiz/QuizPlayPage.jsx
@@ -8,7 +8,7 @@ export default function QuizPlayPage() {
     const [searchParams] = useSearchParams();
 
     const folderId = searchParams.get("folderId");
-    const mode = searchParams.get("mode"); // random/bookmark
+    const mode = searchParams.get("mode");
 
     const [isMusicOn, setIsMusicOn] = useState(false);
     const [localProblems, setLocalProblems] = useState([]);
@@ -16,10 +16,10 @@ export default function QuizPlayPage() {
     const [error, setError] = useState("");
     const [titlePath, setTitlePath] = useState("");
 
-    const problems = localProblems;
-
     const [currentIndex, setCurrentIndex] = useState(0);
     const [showAnswer, setShowAnswer] = useState(false);
+
+    const problems = localProblems;
 
     useEffect(() => {
         async function fetchPracticeProblems() {
@@ -51,14 +51,14 @@ export default function QuizPlayPage() {
         return (
             <div style={{ maxWidth: 800, margin: "0 auto" }}>
                 <h1>QuizPlayPage</h1>
-                <p>folderId가 없습니다. 폴더에서 들어오거나 URL에 folderId를 붙여주세요.</p>
+                <p>folderId가 없습니다. leaf 폴더에서 진입해주세요.</p>
                 <p style={{ opacity: 0.7 }}>
-                    예: <code>/quiz/play?folderId=101</code>
+                    예: <code>/quiz/play?folderId=9</code>
                 </p>
 
                 {mode && (
                     <p style={{ opacity: 0.7 }}>
-                        mode=<code>{mode}</code> 는 아직 연결 전입니다.
+                        mode=<code>{mode}</code> 는 아직 별도 연동 전입니다.
                     </p>
                 )}
 
@@ -100,22 +100,22 @@ export default function QuizPlayPage() {
 
     const goNext = () => {
         const next = currentIndex + 1;
+
         if (next >= problems.length) {
             setCurrentIndex(0);
             setShowAnswer(false);
             return;
         }
+
         setCurrentIndex(next);
         setShowAnswer(false);
     };
 
     const toggleBookmark = () => {
-        const cur = problems[currentIndex];
-        if (!cur) return;
-
         setLocalProblems((prev) =>
             prev.map((p, idx) => {
                 if (idx !== currentIndex) return p;
+
                 return {
                     ...p,
                     meta: {
@@ -128,9 +128,8 @@ export default function QuizPlayPage() {
     };
 
     const goEdit = () => {
-        const cur = problems[currentIndex];
-        if (!cur) return;
-        navigate(`/quiz/${cur.problemId}/edit`);
+        if (!problem?.problemId) return;
+        navigate(`/quiz/${problem.problemId}/edit`);
     };
 
     return (
@@ -151,8 +150,12 @@ export default function QuizPlayPage() {
             <hr style={{ margin: "16px 0" }} />
 
             <div style={{ marginBottom: 16 }}>
-                <div style={{ opacity: 0.7, marginBottom: 6 }}>Q{problem.questionNo}</div>
-                <div style={{ fontSize: 18, fontWeight: 600 }}>{problem.questionText}</div>
+                <div style={{ opacity: 0.7, marginBottom: 6 }}>
+                    Q{problem.questionNo}
+                </div>
+                <div style={{ fontSize: 18, fontWeight: 600 }}>
+                    {problem.questionText}
+                </div>
             </div>
 
             {problem.questionImages?.length > 0 && (
@@ -203,7 +206,9 @@ export default function QuizPlayPage() {
 }
 
 function ExplanationBlocks({ blocks }) {
-    if (!blocks.length) return <div style={{ opacity: 0.6 }}>해설이 없습니다.</div>;
+    if (!blocks.length) {
+        return <div style={{ opacity: 0.6 }}>해설이 없습니다.</div>;
+    }
 
     return (
         <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>

--- a/frontend/src/shared/api/folderApi.js
+++ b/frontend/src/shared/api/folderApi.js
@@ -6,7 +6,7 @@ function normalizeFolderChildren(raw) {
 
     const titlePath =
         breadcrumb.length > 0
-            ? "/" + breadcrumb.map((item) => item.name).join("/")
+            ? "/" + breadcrumb.map((item) => item.name).filter(Boolean).join("/")
             : "/";
 
     return {
@@ -29,50 +29,37 @@ function normalizeFolderChildren(raw) {
     };
 }
 
-function toExplanationBlocks(rawProblem) {
-    if (Array.isArray(rawProblem?.explanationBlocks)) {
-        return rawProblem.explanationBlocks;
+function normalizeExplanationToBlocks(explanation) {
+    if (!explanation || typeof explanation !== "string") {
+        return [];
     }
 
-    if (typeof rawProblem?.explanationText === "string") {
-        return rawProblem.explanationText
-            .split("\n")
-            .map((line) => line.trim())
-            .filter(Boolean)
-            .map((text) => ({
-                type: "TEXT",
-                text,
-            }));
-    }
-
-    return [];
+    return explanation
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((text) => ({
+            type: "TEXT",
+            text,
+        }));
 }
 
-function normalizePracticeResponse(raw) {
+function normalizePracticeResponse(raw, folderId) {
     return {
-        folderId: raw?.folderId ?? null,
-        titlePath: raw?.titlePath ?? "",
-        selectionRule: raw?.selectionRule ?? "FOLDER_ALL",
+        folderId: Number(folderId),
+        titlePath: "",
+        selectionRule: raw?.selectionRule ?? "ALL",
         problems: Array.isArray(raw?.problems)
-            ? raw.problems.map((problem, index) => ({
+            ? raw.problems.map((problem) => ({
                 problemId: problem?.problemId ?? null,
-                titlePath: problem?.titlePath ?? raw?.titlePath ?? "",
-                questionNo:
-                    problem?.questionNo ??
-                    problem?.problemNo ??
-                    problem?.problemNum ??
-                    index + 1,
-                questionText: problem?.questionText ?? "",
-                questionImages: Array.isArray(problem?.questionImages)
-                    ? problem.questionImages
-                    : [],
-                answerText: problem?.answerText ?? "",
-                explanationBlocks: toExplanationBlocks(problem),
+                questionNo: problem?.problemNum ?? 0,
+                questionText: problem?.question ?? "",
+                questionImages: [],
+                answerText: problem?.answer ?? "",
+                explanationBlocks: normalizeExplanationToBlocks(problem?.explanation),
                 meta: {
-                    attemptCount:
-                        problem?.meta?.attemptCount ?? problem?.attemptCount ?? 0,
-                    isBookmarked:
-                        problem?.meta?.isBookmarked ?? problem?.isBookmarked ?? false,
+                    attemptCount: problem?.meta?.attemptCount ?? 0,
+                    isBookmarked: problem?.meta?.isBookmarked ?? false,
                 },
             }))
             : [],
@@ -86,5 +73,5 @@ export async function getFolderChildren(folderId) {
 
 export async function getFolderPractice(folderId) {
     const response = await apiClient.get(`/api/v1/folders/${folderId}/practice`);
-    return normalizePracticeResponse(response.data.result);
+    return normalizePracticeResponse(response.data.result, folderId);
 }


### PR DESCRIPTION
## 📝 작업 내용 설명

leaf 폴더를 클릭하면 해당 폴더에 속한 연습 문제를 backend API로 조회하고,
문제를 한 문제씩 처음부터 끝까지 순차적으로 확인할 수 있도록 프론트 연동을 진행했다.

기존 퀴즈 플레이 화면은 mock 구조를 기준으로 만들어져 있었는데,
이번 작업에서는 `/api/v1/folders/{folderId}/practice` 응답 구조에 맞게 데이터를 정규화하여
실제 API 응답 기반으로 문제/정답/해설/메타 정보를 렌더링하도록 전환했다.

또한 사용성을 높이기 위해
- leaf 폴더 진입 시 경로 문자열 표시
- `폴더 나가기` 버튼 문구 반영
- `이전 문제` 버튼 추가
- 마지막 문제 이후 완료 화면 표시
- 완료 후 폴더 목록으로 복귀

기능까지 함께 반영했다.

## ✅ 작업 내용
- [x] `folderApi.js`에 폴더 연습문제 조회 API 호출 함수 구현/정리
- [x] backend practice 응답 구조에 맞는 데이터 정규화 로직 추가
- [x] `QuizPlayPage.jsx`를 실제 API 응답 기반 렌더링으로 전환
- [x] leaf 폴더 진입 시 해당 폴더 문제 목록 조회
- [x] 문제를 한 문제씩 처음부터 끝까지 순차 표시
- [x] 정답/해설 보기 토글 유지
- [x] API 호출 중 로딩 상태 처리
- [x] API 호출 실패 시 에러 상태 처리
- [x] 문제 없음 빈 상태 처리
- [x] leaf 폴더 경로(titlePath) 표시 개선
- [x] `폴더 나가기` 버튼 문구 반영
- [x] `이전 문제` 버튼 추가
- [x] 마지막 문제 이후 `모두 풀었습니다!` 완료 화면 추가
- [x] 완료 후 폴더 목록으로 복귀하도록 처리
- [x] 로컬 환경에서 practice API 연동 확인

## 🔍 변경 포인트
- 퀴즈 플레이 화면이 더 이상 mock 데이터에 의존하지 않음
- backend practice 응답을 프론트 화면 구조에 맞게 정규화하여 사용
- 문제를 순서대로 탐색하는 플레이 흐름이 실데이터 기반으로 동작
- 이전/다음 문제 이동이 가능해져 탐색 편의성 향상
- 마지막 문제 이후 완료 화면을 제공해 종료 흐름이 자연스러워짐
- leaf 폴더에서 진입한 경로를 제목에 반영해 현재 위치를 더 명확히 표시

## 📌 비고
- 현재 경로 문자열은 폴더 목록 화면에서 leaf 폴더 클릭 시 전달된 state를 기반으로 표시한다.
- 사용자가 URL로 직접 `/quiz/play?folderId=...` 에 진입하는 경우에는 경로 정보가 없을 수 있으므로, 추후 backend practice 응답에 `titlePath`를 포함하거나 별도 breadcrumb 조회로 보완할 수 있다.
- 북마크 토글은 현재 프론트 상태 변경만 반영하며, 실제 저장 API 연동은 별도 작업으로 진행 예정이다.
- 랜덤 문제 / 북마크 문제 모드 연동은 별도 이슈에서 진행 예정이다.