### PR TITLE
fix(backend/problem): 새로 등록되는 문제의 bookmark 값이 true로 저장되도록 변경

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ProblemImportRequest.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ProblemImportRequest.java
@@ -5,16 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class ProblemImportRequest {
-    //    @Getter
-//    @NoArgsConstructor
-//    public static class ImportProblemsFromTextRequest {
-//
-//        @NotNull
-//        private Long folderId;
-//
-//        @NotBlank
-//        private String rawText;
-//    }
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/entity/Problem.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/entity/Problem.java
@@ -81,7 +81,7 @@ public class Problem {
                 questionText,
                 explanationText,
                 answerText,
-                false,
+                true,
                 0,
                 folder
         );


### PR DESCRIPTION
## 📝 작업 내용 설명

본 서비스는 사용자가 등록한 문제를 기본적으로 반복 학습 대상으로 포함하고,
충분히 익숙해져 더 이상 반복해서 볼 필요가 없는 문제만 사용자가 직접 북마크를 해제하는 흐름을 전제로 한다.

하지만 기존 문제 생성 로직에서는 새로 등록되는 문제의 `bookmark` 값이 `false`로 저장되고 있어,
문제 등록 직후 해당 문제가 북마크 기반 풀이 흐름에 포함되지 않는 문제가 있었다.

이번 작업에서는 문제 생성 시 기본 북마크 값을 `true`로 저장하도록 수정하여,
새로 등록한 문제가 곧바로 반복 학습 대상에 포함되도록 변경했다.

## ✅ 작업 내용

- [x] `Problem.of()` 팩토리 메서드에서 `bookmark` 기본값을 `false`에서 `true`로 수정
- [x] 문제 일괄 등록 시 새로 생성되는 문제가 기본 북마크 상태로 저장되도록 변경
- [x] `Problem.of()` 호출 흐름을 확인하여 문제 생성 로직에 반영되는지 검토
- [x] 문제 생성 관련 불필요한 주석 제거


## 🔍 주요 변경 포인트

- 신규 문제의 기본 상태가 `bookmark = false`에서 `bookmark = true`로 변경됨
- 문제 등록 직후 해당 문제가 북마크 기반 풀이 대상에 포함되도록 개선됨
- 서비스의 학습 흐름이 “기본 포함 후 사용자가 제외”하는 방식으로 정렬됨
- 문제 생성 책임을 가진 `Problem.of()`에서 기본값을 관리하도록 유지하여 생성 로직의 일관성을 확보함


## 🧪 확인한 내용

- [x] 로컬 환경에서 정상 동작 확인
- [x] API 요청/응답 확인
- [x] UI 상태 처리 확인


## 🔗 관련 이슈

#42 
