### PR TITLE
fix(backend/problem): 문제 일괄 등록 시 leaf 폴더 검증 추가

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
@@ -23,7 +23,8 @@ public enum ErrorStatus implements BaseErrorCode {
     // 문제 관련 에러
     PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROBLEM4041", "존재하지 않는 문제입니다."),
     PROBLEM_TEXT_PARSE_FAILED(HttpStatus.BAD_REQUEST, "PROBLEM4001", "문제 문자열 파싱에 실패했습니다."),
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "PROBLEM4002", "잘못된 문제 입력입니다.");
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "PROBLEM4002", "잘못된 문제 입력입니다."),
+    PROBLEM_IMPORT_TARGET_NOT_LEAF(HttpStatus.BAD_REQUEST, "PROBLEM4003", "문제 일괄 등록은 leaf 폴더에만 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
@@ -43,6 +43,8 @@ public class ProblemCommandServiceImpl implements ProblemCommandService {
         Folder folder = folderRepository.findById(request.getFolderId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.FOLDER_NOT_FOUND));
 
+        validateLeafFolderForProblemImport(folder);
+
         List<ParsedProblemContent> parsedProblems = problemTextParser.parse(request.getRawText());
 
         int startProblemNum = getNextProblemNum(folder.getFolderId());
@@ -71,5 +73,13 @@ public class ProblemCommandServiceImpl implements ProblemCommandService {
         return problemRepository.findTopByFolder_FolderIdOrderByProblemNumDesc(folderId)
                 .map(problem -> problem.getProblemNum() + 1)
                 .orElse(1);
+    }
+
+    private void validateLeafFolderForProblemImport(Folder folder) {
+        boolean hasChildFolders = folderRepository.existsByParentFolder_FolderId(folder.getFolderId());
+
+        if (hasChildFolders) {
+            throw new GeneralException(ErrorStatus.PROBLEM_IMPORT_TARGET_NOT_LEAF);
+        }
     }
 }


### PR DESCRIPTION
## 📝 작업 내용 설명
문제 일괄 등록 시 대상 폴더가 leaf 폴더인지 검증하도록 수정했습니다.
서비스 구조상 문제는 실제 풀이 단위가 되는 최하위 폴더, 즉 leaf 폴더에만 등록되어야 하므로, 
문제 일괄 등록 전에 대상 폴더의 하위 폴더 존재 여부를 확인하고 non-leaf 폴더인 경우 예외를 반환하도록 수정했습니다.


## ✅ 작업 내용

- [x] 문제 일괄 등록 서비스 로직에 leaf 폴더 검증 추가
- [x] 대상 폴더에 하위 폴더가 존재하는 경우 문제 등록 차단
- [x] non-leaf 폴더 요청 시 전용 예외 코드 반환


## 🔍 주요 변경 포인트

- 문제 일괄 등록 시 폴더 존재 여부 확인 이후, 문제 파싱 전에 leaf 폴더 여부를 먼저 검증하도록 변경했습니다.
- 대상 폴더에 하위 폴더가 존재하는 경우 `PROBLEM_IMPORT_TARGET_NOT_LEAF` 예외가 발생하도록 처리했습니다.


## 🧪 확인한 내용

- [x] 로컬 환경에서 정상 동작 확인
- [x] API 요청/응답 확인
- [x] UI 상태 처리 확인


## 🔗 관련 이슈

#44
