### PR TITLE
feat(backend/folder): 폴더 추가 API 구현

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
@@ -19,6 +19,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 폴더 관련 에러
     FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER4041", "존재하지 않는 폴더입니다."),
     FOLDER_NOT_LEAF(HttpStatus.BAD_REQUEST, "FOLDER4001", "연습 문제 조회는 leaf 폴더에서만 가능합니다."),
+    DUPLICATE_FOLDER_NAME(HttpStatus.BAD_REQUEST, "FOLDER4001", "같은 부모 폴더 아래에 동일한 이름의 폴더가 이미 존재합니다."),
 
     // 문제 관련 에러
     PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROBLEM4041", "존재하지 않는 문제입니다."),

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/FolderRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/FolderRestController.java
@@ -1,13 +1,19 @@
 package com.hhd1337.jatuli_quiz.domain.folder;
 
 import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
+import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderRequest;
+import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse;
 import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.FolderChildrenResponse;
 import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.PracticeResponse;
+import com.hhd1337.jatuli_quiz.domain.folder.service.FolderCommandService;
 import com.hhd1337.jatuli_quiz.domain.folder.service.FolderQueryService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class FolderRestController {
     private final FolderQueryService folderQueryService;
+    private final FolderCommandService folderCommandService;
 
     @Operation(
             summary = "폴더 하위 목록 조회",
@@ -42,5 +49,25 @@ public class FolderRestController {
     @GetMapping("/{folderId}/practice")
     public ApiResponse<PracticeResponse> getPracticeProblems(@PathVariable Long folderId) {
         return ApiResponse.onSuccess(folderQueryService.getPracticeProblems(folderId));
+    }
+
+    @Operation(
+            summary = "폴더 추가",
+            description = """
+                    특정 부모 폴더 아래에 새로운 하위 폴더를 생성합니다.
+                    
+                    홈 화면에서 바로 보이는 폴더들(예: 자바, 스프링, JPA, DB, 도커)은
+                    루트 폴더의 바로 아래 자식 폴더입니다.
+                    따라서 해당 폴더들을 생성하려면 parentFolderId로 루트 폴더 ID인 1을 전달합니다.
+                    
+                    부모 폴더가 존재하지 않으면 폴더 생성을 차단합니다.
+                    같은 부모 폴더 아래에 동일한 이름의 자식 폴더가 이미 존재하는 경우에도 폴더 생성을 차단합니다.
+                    """
+    )
+    @PostMapping
+    public ApiResponse<FolderResponse.CreateFolderResponse> createFolder(
+            @Valid @RequestBody FolderRequest.CreateFolderRequest request
+    ) {
+        return ApiResponse.onSuccess(folderCommandService.createFolder(request));
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/converter/FolderConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/converter/FolderConverter.java
@@ -1,5 +1,6 @@
 package com.hhd1337.jatuli_quiz.domain.folder.converter;
 
+import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse;
 import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.FolderChildrenResponse;
 import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.PracticeProblemDto;
 import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse.PracticeProblemMetaDto;
@@ -70,6 +71,17 @@ public class FolderConverter {
         return PracticeProblemMetaDto.builder()
                 .attemptCount(problem.getSolvedCount())
                 .isBookmarked(problem.getIsBookmarked())
+                .build();
+    }
+
+    public static FolderResponse.CreateFolderResponse toCreateFolderResponse(Folder folder) {
+        return FolderResponse.CreateFolderResponse.builder()
+                .folderId(folder.getFolderId())
+                .parentFolderId(folder.getParentFolder().getFolderId())
+                .name(folder.getName())
+                .fullPath(folder.getFullPath())
+                .depth(folder.getDepth())
+                .problemCount(folder.getProblemCount())
                 .build();
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/dto/FolderRequest.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/dto/FolderRequest.java
@@ -1,0 +1,24 @@
+package com.hhd1337.jatuli_quiz.domain.folder.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FolderRequest {
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateFolderRequest {
+
+        @NotNull(message = "부모 폴더 ID는 필수입니다.")
+        private Long parentFolderId;
+
+        @NotBlank(message = "폴더 이름은 필수입니다.")
+        @Size(max = 100, message = "폴더 이름은 100자를 초과할 수 없습니다.")
+        private String name;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/dto/FolderResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/dto/FolderResponse.java
@@ -65,4 +65,17 @@ public class FolderResponse {
         private Integer attemptCount;
         private Boolean isBookmarked;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateFolderResponse {
+        private Long folderId;
+        private Long parentFolderId;
+        private String name;
+        private String fullPath;
+        private Integer depth;
+        private Integer problemCount;
+    }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/entity/Folder.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/entity/Folder.java
@@ -54,6 +54,26 @@ public class Folder {
         this.parentFolder = parentFolder;
     }
 
+    public static Folder createChildFolder(String name, Folder parentFolder) {
+        return new Folder(
+                buildFullPath(parentFolder, name),
+                parentFolder.getDepth() + 1,
+                name,
+                0,
+                parentFolder
+        );
+    }
+
+    private static String buildFullPath(Folder parentFolder, String name) {
+        String parentFullPath = parentFolder.getFullPath();
+
+        if (parentFullPath == null || parentFullPath.isBlank() || parentFullPath.equals("/")) {
+            return "/" + name;
+        }
+
+        return parentFullPath + "/" + name;
+    }
+
     public void increaseProblemCount(int count) {
         if (this.problemCount == null) {
             this.problemCount = 0;

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/repository/FolderRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/repository/FolderRepository.java
@@ -15,5 +15,6 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
     boolean existsByParentFolder_FolderId(Long folderId);
 
     List<Folder> findAllByParentFolder_FolderIdOrderByFolderIdAsc(Long parentFolderId);
-    
+
+    boolean existsByParentFolder_FolderIdAndName(Long parentFolderId, String name);
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderCommandService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderCommandService.java
@@ -1,0 +1,11 @@
+package com.hhd1337.jatuli_quiz.domain.folder.service;
+
+import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderRequest;
+import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse;
+
+public interface FolderCommandService {
+
+    FolderResponse.CreateFolderResponse createFolder(
+            FolderRequest.CreateFolderRequest request
+    );
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderCommandServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderCommandServiceImpl.java
@@ -1,0 +1,50 @@
+package com.hhd1337.jatuli_quiz.domain.folder.service;
+
+import com.hhd1337.jatuli_quiz.common.exception.GeneralException;
+import com.hhd1337.jatuli_quiz.common.exception.code.status.ErrorStatus;
+import com.hhd1337.jatuli_quiz.domain.folder.converter.FolderConverter;
+import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderRequest;
+import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse;
+import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
+import com.hhd1337.jatuli_quiz.domain.folder.repository.FolderRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FolderCommandServiceImpl implements FolderCommandService {
+
+    private final FolderRepository folderRepository;
+
+    @Override
+    public FolderResponse.CreateFolderResponse createFolder(
+            FolderRequest.CreateFolderRequest request
+    ) {
+        Folder parentFolder = folderRepository.findByFolderId(request.getParentFolderId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.FOLDER_NOT_FOUND));
+
+        validateDuplicateFolderName(parentFolder.getFolderId(), request.getName());
+
+        Folder folder = Folder.createChildFolder(
+                request.getName(),
+                parentFolder
+        );
+
+        Folder savedFolder = folderRepository.save(folder);
+
+        return FolderConverter.toCreateFolderResponse(savedFolder);
+    }
+
+    private void validateDuplicateFolderName(Long parentFolderId, String folderName) {
+        boolean existsSameNameFolder = folderRepository.existsByParentFolder_FolderIdAndName(
+                parentFolderId,
+                folderName
+        );
+
+        if (existsSameNameFolder) {
+            throw new GeneralException(ErrorStatus.DUPLICATE_FOLDER_NAME);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용 설명

문제 일괄 등록 전에 문제를 담을 폴더를 미리 생성할 수 있도록 폴더 추가 API를 구현했습니다.
이번 작업에서는 특정 부모 폴더 아래에 새로운 하위 폴더를 생성할 수 있도록 API를 추가했습니다.  
부모 폴더가 존재하지 않는 경우에는 폴더 생성을 차단하고, 같은 부모 폴더 아래 동일한 이름의 자식 폴더가 이미 존재하는 경우에도 예외를 반환하도록 처리했습니다.

## ✅ 작업 내용

- [x] 폴더 추가 API 엔드포인트 구현
- [x] 부모 폴더 존재 여부 검증 로직 추가
- [x] 동일 부모 폴더 내 중복 폴더명 검증 로직 추가
- [x] 폴더 생성 응답 변환 로직 추가
- [x] 폴더 생성 관련 에러 상태 추가


## 🔍 주요 변경 포인트

- `POST /api/v1/folders` 요청을 통해 특정 부모 폴더 아래에 새 하위 폴더를 생성할 수 있도록 했습니다.
- 홈 화면에서 바로 보이는 폴더들처럼 루트 폴더 바로 아래에 폴더를 생성하려면 `parentFolderId`로 루트 폴더 ID를 전달하도록 설계했습니다.
- 같은 부모 폴더 아래에 동일한 이름의 자식 폴더가 중복 생성되지 않도록 검증을 추가했습니다.


## 🧪 확인한 내용

- [x] 로컬 환경에서 정상 동작 확인
- [x] API 요청/응답 확인
- [x] UI 상태 처리 확인


## 🔗 관련 이슈

#46
