### PR TITLE
feat(backend/problem): 서비스 내 모든 북마크 문제 전체순회 풀이 API 구현

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
@@ -25,7 +25,8 @@ public enum ErrorStatus implements BaseErrorCode {
     PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROBLEM4041", "존재하지 않는 문제입니다."),
     PROBLEM_TEXT_PARSE_FAILED(HttpStatus.BAD_REQUEST, "PROBLEM4001", "문제 문자열 파싱에 실패했습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "PROBLEM4002", "잘못된 문제 입력입니다."),
-    PROBLEM_IMPORT_TARGET_NOT_LEAF(HttpStatus.BAD_REQUEST, "PROBLEM4003", "문제 일괄 등록은 leaf 폴더에만 가능합니다.");
+    PROBLEM_IMPORT_TARGET_NOT_LEAF(HttpStatus.BAD_REQUEST, "PROBLEM4003", "문제 일괄 등록은 leaf 폴더에만 가능합니다."),
+    BOOKMARKED_PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROBLEM4004", "북마크된 문제가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/dto/PracticeRequest.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/dto/PracticeRequest.java
@@ -1,0 +1,21 @@
+package com.hhd1337.jatuli_quiz.domain.practice.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class PracticeRequest {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetBookmarkedPracticeProblemsRequest {
+
+        @NotNull(message = "조회할 문제 개수는 필수입니다.")
+        @Min(value = 1, message = "조회할 문제 개수는 1개 이상이어야 합니다.")
+        @Max(value = 50, message = "조회할 문제 개수는 50개 이하여야 합니다.")
+        private Integer size;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/dto/PracticeRequest.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/dto/PracticeRequest.java
@@ -1,5 +1,6 @@
 package com.hhd1337.jatuli_quiz.domain.practice.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -13,9 +14,10 @@ public class PracticeRequest {
     @AllArgsConstructor
     public static class GetBookmarkedPracticeProblemsRequest {
 
+        @Schema(description = "이번 문제풀이 세트에서 받아올 최대 문제 개수", example = "10")
         @NotNull(message = "조회할 문제 개수는 필수입니다.")
         @Min(value = 1, message = "조회할 문제 개수는 1개 이상이어야 합니다.")
         @Max(value = 50, message = "조회할 문제 개수는 50개 이하여야 합니다.")
-        private Integer size;
+        private Integer problemCount;
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/dto/PracticeResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/dto/PracticeResponse.java
@@ -34,4 +34,35 @@ public class PracticeResponse {
         private Integer attemptCount;
         private Boolean isBookmarked;
     }
+ 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class GetBookmarkedPracticeProblemsResponse {
+
+        private String selectionRule;
+        private Integer requestedSize;
+        private Integer returnedSize;
+        private Integer folderProblemLimit;
+        private Long nextStartLeafFolderId;
+        private List<BookmarkedPracticeProblemItem> problems;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class BookmarkedPracticeProblemItem {
+
+        private Long problemId;
+        private Integer problemNum;
+        private String questionText;
+        private String explanationText;
+        private String answerText;
+        private Boolean isBookmarked;
+        private Integer solvedCount;
+
+        private Long folderId;
+        private String folderName;
+        private String folderPath;
+    }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/entity/PracticeCursor.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/entity/PracticeCursor.java
@@ -1,0 +1,48 @@
+package com.hhd1337.jatuli_quiz.domain.practice.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "practice_cursor")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PracticeCursor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cursor_id")
+    private Long cursorId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cursor_type", nullable = false, unique = true, length = 50)
+    private PracticeCursorType cursorType;
+
+    @Column(name = "last_leaf_folder_id")
+    private Long lastLeafFolderId;
+
+    protected PracticeCursor(
+            PracticeCursorType cursorType,
+            Long lastLeafFolderId
+    ) {
+        this.cursorType = cursorType;
+        this.lastLeafFolderId = lastLeafFolderId;
+    }
+
+    public static PracticeCursor create(PracticeCursorType cursorType) {
+        return new PracticeCursor(cursorType, null);
+    }
+
+    public void updateLastLeafFolderId(Long lastLeafFolderId) {
+        this.lastLeafFolderId = lastLeafFolderId;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/entity/PracticeCursorType.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/entity/PracticeCursorType.java
@@ -1,0 +1,6 @@
+package com.hhd1337.jatuli_quiz.domain.practice.entity;
+
+public enum PracticeCursorType {
+    // 서비스의 모든 북마크 문제를 각 폴더 당 2문제씩 라운드로빈 순회
+    BOOKMARKED_LEAF_ROUND_ROBIN
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/repository/PracticeCursorRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/repository/PracticeCursorRepository.java
@@ -1,0 +1,25 @@
+package com.hhd1337.jatuli_quiz.domain.practice.repository;
+
+import com.hhd1337.jatuli_quiz.domain.practice.entity.PracticeCursor;
+import com.hhd1337.jatuli_quiz.domain.practice.entity.PracticeCursorType;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PracticeCursorRepository extends JpaRepository<PracticeCursor, Long> {
+
+    Optional<PracticeCursor> findByCursorType(PracticeCursorType cursorType);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select pc
+            from PracticeCursor pc
+            where pc.cursorType = :cursorType
+            """)
+    Optional<PracticeCursor> findByCursorTypeWithLock(
+            @Param("cursorType") PracticeCursorType cursorType
+    );
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
@@ -1,6 +1,8 @@
 package com.hhd1337.jatuli_quiz.domain.problem;
 
 import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
+import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeRequest;
+import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportRequest;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportResponse;
@@ -68,5 +70,33 @@ public class ProblemRestController {
                 new ProblemImportRequest.ImportProblemsFromTextRequest(folderId, rawText);
 
         return ApiResponse.onSuccess(problemCommandService.importProblemsFromText(request));
+    }
+
+    @Operation(
+            summary = "북마크 문제 전체순회 풀이 문제 조회",
+            description = """
+                    서비스 전체 leaf 폴더에 존재하는 북마크 문제들을 순회하며 풀이 문제 목록을 제공합니다.
+                    
+                    현재 MVP에서는 단일 사용자 기준으로 Problem의 isBookmarked, solvedCount 값을 사용합니다.
+                    북마크된 문제만 조회 대상에 포함하며, 북마크가 해제된 문제는 순회 대상에서 제외됩니다.
+                    
+                    순회 방식은 leaf 폴더 라운드로빈 방식입니다.
+                    마지막으로 문제를 제공한 leaf 폴더 위치를 practice_cursor에 저장하고,
+                    다음 요청 시 해당 폴더 다음 leaf 폴더부터 이어서 조회합니다.
+                    
+                    각 leaf 폴더에서는 solvedCount가 가장 낮은 문제를 우선 제공합니다.
+                    solvedCount가 같으면 problemNum 오름차순, problemId 오름차순으로 정렬합니다.
+                    
+                    한 leaf 폴더당 최대 2문제씩 연속으로 제공한 뒤 다음 leaf 폴더로 넘어갑니다.
+                    예: A1, A2, B1, B2, C1, C2
+                    
+                    cursor 갱신이 발생하므로 단순 조회가 아닌 POST 방식으로 제공합니다.
+                    """
+    )
+    @PostMapping("/bookmarked/practice")
+    public ApiResponse<PracticeResponse.GetBookmarkedPracticeProblemsResponse> getBookmarkedPracticeProblems(
+            @RequestBody PracticeRequest.GetBookmarkedPracticeProblemsRequest request
+    ) {
+        return ApiResponse.onSuccess(problemCommandService.getBookmarkedPracticeProblems(request));
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
@@ -8,6 +8,7 @@ import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportRequest;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.service.ProblemCommandService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -95,7 +96,7 @@ public class ProblemRestController {
     )
     @PostMapping("/bookmarked/practice")
     public ApiResponse<PracticeResponse.GetBookmarkedPracticeProblemsResponse> getBookmarkedPracticeProblems(
-            @RequestBody PracticeRequest.GetBookmarkedPracticeProblemsRequest request
+            @Valid @RequestBody PracticeRequest.GetBookmarkedPracticeProblemsRequest request
     ) {
         return ApiResponse.onSuccess(problemCommandService.getBookmarkedPracticeProblems(request));
     }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/converter/ProblemConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/converter/ProblemConverter.java
@@ -1,5 +1,7 @@
 package com.hhd1337.jatuli_quiz.domain.problem.converter;
 
+import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
+import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
@@ -34,6 +36,43 @@ public class ProblemConverter {
                 .savedCount(savedProblems.size())
                 .problems(savedProblems.stream()
                         .map(ProblemConverter::toImportedProblemItem)
+                        .toList())
+                .build();
+    }
+
+    public static PracticeResponse.BookmarkedPracticeProblemItem toBookmarkedPracticeProblemItem(
+            Problem problem
+    ) {
+        Folder folder = problem.getFolder();
+
+        return PracticeResponse.BookmarkedPracticeProblemItem.builder()
+                .problemId(problem.getProblemId())
+                .problemNum(problem.getProblemNum())
+                .questionText(problem.getQuestionText())
+                .explanationText(problem.getExplanationText())
+                .answerText(problem.getAnswerText())
+                .isBookmarked(problem.getIsBookmarked())
+                .solvedCount(problem.getSolvedCount())
+                .folderId(folder.getFolderId())
+                .folderName(folder.getName())
+                .folderPath(folder.getFullPath())
+                .build();
+    }
+
+    public static PracticeResponse.GetBookmarkedPracticeProblemsResponse toBookmarkedPracticeProblemsResponse(
+            Integer requestedSize,
+            Integer folderProblemLimit,
+            Long nextStartLeafFolderId,
+            List<Problem> problems
+    ) {
+        return PracticeResponse.GetBookmarkedPracticeProblemsResponse.builder()
+                .selectionRule("BOOKMARKED_LEAF_ROUND_ROBIN")
+                .requestedSize(requestedSize)
+                .returnedSize(problems.size())
+                .folderProblemLimit(folderProblemLimit)
+                .nextStartLeafFolderId(nextStartLeafFolderId)
+                .problems(problems.stream()
+                        .map(ProblemConverter::toBookmarkedPracticeProblemItem)
                         .toList())
                 .build();
     }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
@@ -4,8 +4,10 @@ import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
 import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
     int countByFolder(Folder folder);
@@ -34,5 +36,34 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
     List<Problem> findBookmarkedProblemsOrderByAttemptCountAsc();
 
     Optional<Problem> findTopByFolder_FolderIdOrderByProblemNumDesc(Long folderId);
+
+    @Query("""
+            select distinct f
+            from Problem p
+            join p.folder f
+            where p.isBookmarked = true
+              and not exists (
+                  select 1
+                  from Folder child
+                  where child.parentFolder = f
+              )
+            order by f.folderId asc
+            """)
+    List<Folder> findLeafFoldersHavingBookmarkedProblemsOrderByFolderIdAsc();
+
+    @Query("""
+            select p
+            from Problem p
+            join fetch p.folder f
+            where f.folderId = :folderId
+              and p.isBookmarked = true
+            order by coalesce(p.solvedCount, 0) asc,
+                     p.problemNum asc,
+                     p.problemId asc
+            """)
+    List<Problem> findBookmarkedProblemsByFolderIdForPractice(
+            @Param("folderId") Long folderId,
+            Pageable pageable
+    );
 
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandService.java
@@ -1,5 +1,7 @@
 package com.hhd1337.jatuli_quiz.domain.problem.service;
 
+import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeRequest;
+import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportRequest;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportResponse;
@@ -10,5 +12,9 @@ public interface ProblemCommandService {
 
     ProblemImportResponse.ImportProblemsFromTextResponse importProblemsFromText(
             ProblemImportRequest.ImportProblemsFromTextRequest request
+    );
+
+    PracticeResponse.GetBookmarkedPracticeProblemsResponse getBookmarkedPracticeProblems(
+            PracticeRequest.GetBookmarkedPracticeProblemsRequest request
     );
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
@@ -4,6 +4,11 @@ import com.hhd1337.jatuli_quiz.common.exception.GeneralException;
 import com.hhd1337.jatuli_quiz.common.exception.code.status.ErrorStatus;
 import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
 import com.hhd1337.jatuli_quiz.domain.folder.repository.FolderRepository;
+import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeRequest;
+import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
+import com.hhd1337.jatuli_quiz.domain.practice.entity.PracticeCursor;
+import com.hhd1337.jatuli_quiz.domain.practice.entity.PracticeCursorType;
+import com.hhd1337.jatuli_quiz.domain.practice.repository.PracticeCursorRepository;
 import com.hhd1337.jatuli_quiz.domain.problem.converter.ProblemConverter;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ParsedProblemContent;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
@@ -14,6 +19,7 @@ import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,9 +28,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ProblemCommandServiceImpl implements ProblemCommandService {
 
+    private static final int FOLDER_PROBLEM_LIMIT = 2;
+
     private final ProblemRepository problemRepository;
     private final FolderRepository folderRepository;
     private final ProblemTextParser problemTextParser;
+    private final PracticeCursorRepository practiceCursorRepository;
 
     @Override
     public ProblemBookmarkResponse.ToggleBookmarkResponse toggleBookmark(Long problemId) {
@@ -81,5 +90,117 @@ public class ProblemCommandServiceImpl implements ProblemCommandService {
         if (hasChildFolders) {
             throw new GeneralException(ErrorStatus.PROBLEM_IMPORT_TARGET_NOT_LEAF);
         }
+    }
+
+    @Override
+    public PracticeResponse.GetBookmarkedPracticeProblemsResponse getBookmarkedPracticeProblems(
+            PracticeRequest.GetBookmarkedPracticeProblemsRequest request
+    ) {
+        int size = normalizePracticeSize(request.getSize());
+
+        PracticeCursor cursor = getOrCreateBookmarkedPracticeCursor();
+
+        List<Folder> leafFolders = problemRepository.findLeafFoldersHavingBookmarkedProblemsOrderByFolderIdAsc();
+
+        if (leafFolders.isEmpty()) {
+            throw new GeneralException(ErrorStatus.BOOKMARKED_PROBLEM_NOT_FOUND);
+        }
+
+        List<Folder> orderedLeafFolders = reorderLeafFoldersFromNextCursor(
+                leafFolders,
+                cursor.getLastLeafFolderId()
+        );
+
+        List<Problem> selectedProblems = new ArrayList<>();
+        Long lastSelectedLeafFolderId = null;
+
+        for (Folder leafFolder : orderedLeafFolders) {
+            if (selectedProblems.size() >= size) {
+                break;
+            }
+
+            int remainingSize = size - selectedProblems.size();
+            int limit = Math.min(FOLDER_PROBLEM_LIMIT, remainingSize);
+
+            List<Problem> problemsInFolder = problemRepository.findBookmarkedProblemsByFolderIdForPractice(
+                    leafFolder.getFolderId(),
+                    PageRequest.of(0, limit)
+            );
+
+            if (!problemsInFolder.isEmpty()) {
+                selectedProblems.addAll(problemsInFolder);
+                lastSelectedLeafFolderId = leafFolder.getFolderId();
+            }
+        }
+
+        if (selectedProblems.isEmpty()) {
+            throw new GeneralException(ErrorStatus.BOOKMARKED_PROBLEM_NOT_FOUND);
+        }
+
+        cursor.updateLastLeafFolderId(lastSelectedLeafFolderId);
+
+        return ProblemConverter.toBookmarkedPracticeProblemsResponse(
+                size,
+                FOLDER_PROBLEM_LIMIT,
+                lastSelectedLeafFolderId,
+                selectedProblems
+        );
+    }
+
+    private int normalizePracticeSize(Integer size) {
+        if (size == null) {
+            return 10;
+        }
+
+        if (size < 1) {
+            return 10;
+        }
+
+        return Math.min(size, 50);
+    }
+
+    private PracticeCursor getOrCreateBookmarkedPracticeCursor() {
+        return practiceCursorRepository.findByCursorTypeWithLock(
+                        PracticeCursorType.BOOKMARKED_LEAF_ROUND_ROBIN
+                )
+                .orElseGet(() -> practiceCursorRepository.save(
+                        PracticeCursor.create(PracticeCursorType.BOOKMARKED_LEAF_ROUND_ROBIN)
+                ));
+    }
+
+    private List<Folder> reorderLeafFoldersFromNextCursor(
+            List<Folder> leafFolders,
+            Long lastLeafFolderId
+    ) {
+        if (lastLeafFolderId == null) {
+            return leafFolders;
+        }
+
+        int lastIndex = findFolderIndex(leafFolders, lastLeafFolderId);
+
+        if (lastIndex == -1) {
+            return leafFolders;
+        }
+
+        int nextIndex = (lastIndex + 1) % leafFolders.size();
+
+        List<Folder> reordered = new ArrayList<>();
+
+        for (int i = 0; i < leafFolders.size(); i++) {
+            int index = (nextIndex + i) % leafFolders.size();
+            reordered.add(leafFolders.get(index));
+        }
+
+        return reordered;
+    }
+
+    private int findFolderIndex(List<Folder> leafFolders, Long folderId) {
+        for (int i = 0; i < leafFolders.size(); i++) {
+            if (leafFolders.get(i).getFolderId().equals(folderId)) {
+                return i;
+            }
+        }
+
+        return -1;
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
@@ -96,7 +96,7 @@ public class ProblemCommandServiceImpl implements ProblemCommandService {
     public PracticeResponse.GetBookmarkedPracticeProblemsResponse getBookmarkedPracticeProblems(
             PracticeRequest.GetBookmarkedPracticeProblemsRequest request
     ) {
-        int size = normalizePracticeSize(request.getSize());
+        int requestedProblemCount = normalizePracticeProblemCount(request.getProblemCount());
 
         PracticeCursor cursor = getOrCreateBookmarkedPracticeCursor();
 
@@ -115,12 +115,12 @@ public class ProblemCommandServiceImpl implements ProblemCommandService {
         Long lastSelectedLeafFolderId = null;
 
         for (Folder leafFolder : orderedLeafFolders) {
-            if (selectedProblems.size() >= size) {
+            if (selectedProblems.size() >= requestedProblemCount) {
                 break;
             }
 
-            int remainingSize = size - selectedProblems.size();
-            int limit = Math.min(FOLDER_PROBLEM_LIMIT, remainingSize);
+            int remainingProblemCount = requestedProblemCount - selectedProblems.size();
+            int limit = Math.min(FOLDER_PROBLEM_LIMIT, remainingProblemCount);
 
             List<Problem> problemsInFolder = problemRepository.findBookmarkedProblemsByFolderIdForPractice(
                     leafFolder.getFolderId(),
@@ -140,14 +140,14 @@ public class ProblemCommandServiceImpl implements ProblemCommandService {
         cursor.updateLastLeafFolderId(lastSelectedLeafFolderId);
 
         return ProblemConverter.toBookmarkedPracticeProblemsResponse(
-                size,
+                requestedProblemCount,
                 FOLDER_PROBLEM_LIMIT,
                 lastSelectedLeafFolderId,
                 selectedProblems
         );
     }
 
-    private int normalizePracticeSize(Integer size) {
+    private int normalizePracticeProblemCount(Integer size) {
         if (size == null) {
             return 10;
         }


### PR DESCRIPTION
## 📝 작업 내용 설명

서비스 내 모든 북마크 문제를 leaf 폴더 단위로 순회하며 풀 수 있는 API를 구현했습니다.
사용자가 북마크한 문제들을 서비스 전체 범위에서 반복 복습할 수 있도록 하는 API 입니다.
북마크된 문제만 순회 대상으로 삼고, 북마크 문제가 존재하는 leaf 폴더를 순서대로 돌면서 각 폴더별로 2문제씩 제공합니다. 
각 폴더 안에서는 아직 덜 푼 문제를 우선 제공하기 위해 `solvedCount`가 낮은 문제부터 선택하며, 동일한 경우 `problemNum`, `problemId` 기준으로 정렬합니다.
또한 단일 사용자 MVP 기준으로 마지막 순회 위치를 저장하기 위한 전역 cursor를 추가하여, 다음 요청 시 이전에 마지막으로 제공한 leaf 폴더 이후부터 이어서 문제를 제공할 수 있도록 했습니다.


## ✅ 작업 내용

- [x] 북마크 문제 전체순회 풀이 API 추가
- [x] 북마크 문제가 존재하는 leaf 폴더 조회 로직 추가
- [x] leaf 폴더별 북마크 문제 조회 로직 추가
- [x] leaf 폴더당 최대 2문제씩 제공하는 순회 로직 구현
- [x] 폴더 내부 문제 정렬 기준 적용
  - [x] `solvedCount ASC`
  - [x] `problemNum ASC`
  - [x] `problemId ASC`
- [x] 마지막으로 순회한 leaf 폴더 위치를 저장하는 전역 cursor 추가
- [x] 문제풀이 요청 DTO 및 응답 DTO 구성
- [x] 요청 문제 개수 검증 적용
- [x] Swagger 설명 추가


## 🔍 주요 변경 포인트

- `POST /problems/bookmarked/practice` API를 추가했습니다.
- 요청 바디의 `problemCount` 값을 기준으로 이번 문제풀이 세트에서 받아올 최대 문제 개수를 지정할 수 있도록 했습니다.
- 북마크된 문제만 조회 대상에 포함되며, 북마크가 해제된 문제는 전체 순회 대상에서 제외됩니다.
- 북마크 문제가 존재하는 leaf 폴더를 기준으로 순회하며, 각 leaf 폴더에서 최대 2문제씩 연속으로 제공합니다.
- 각 폴더 내부에서는 `solvedCount`, `problemNum`, `problemId` 순으로 정렬하여 문제를 선택합니다.
- `practice_cursor`를 통해 마지막으로 문제를 제공한 leaf 폴더 위치를 저장하고, 다음 요청 시 해당 위치 이후부터 이어서 순회하도록 했습니다.
- 현재 서비스는 단일 사용자 MVP이므로 `Member` 테이블은 추가하지 않고, 전역 cursor 방식으로 구현했습니다.


## 🧪 확인한 내용

- [x] 로컬 환경에서 정상 동작 확인
- [x] API 요청/응답 확인
- [x] 북마크된 문제만 응답에 포함되는지 확인
- [x] leaf 폴더당 최대 2문제씩 제공되는지 확인
- [x] `problemCount` 값에 따라 반환 문제 개수가 제한되는지 확인
- [x] 동일 폴더 내부에서 `solvedCount`, `problemNum`, `problemId` 순으로 정렬되는지 확인
- [x] cursor 기준으로 다음 leaf 폴더부터 순회가 이어지는지 확인



## 📌 비고

이번 PR에서는 북마크 문제 전체순회 문제 제공 API까지만 구현했습니다.

문제를 실제로 풀었음을 기록하는 `POST /problems/{problemId}/solve` API는 후속 작업에서 구현할 예정입니다. 따라서 현재는 문제를 제공받아도 `solvedCount`가 자동으로 증가하지 않습니다.

현재 MVP는 단일 사용자 기준으로 구현되어 있으므로, `Problem.isBookmarked`, `Problem.solvedCount`, `practice_cursor`는 전역 상태로 관리됩니다. 향후 회원 기능이 추가될 경우 사용자별 북마크/풀이 횟수/순회 위치를 관리하기 위해 `member_problem_state`, `member_practice_cursor` 구조로 분리할 수 있습니다.


## 🔗 관련 이슈

closes #48