### PR TITLE
feat(backend/progress): 레벨 정책 변경에 따른 북마크 순회 진행도 반영

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/service/HomeQueryServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/service/HomeQueryServiceImpl.java
@@ -7,7 +7,10 @@ import com.hhd1337.jatuli_quiz.domain.folder.repository.FolderRepository;
 import com.hhd1337.jatuli_quiz.domain.home.converter.HomeConverter;
 import com.hhd1337.jatuli_quiz.domain.home.dto.HomeResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
+import com.hhd1337.jatuli_quiz.domain.progress.entity.LearningProgress;
+import com.hhd1337.jatuli_quiz.domain.progress.repository.LearningProgressRepository;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,14 +23,16 @@ public class HomeQueryServiceImpl implements HomeQueryService {
 
     private static final Long ROOT_FOLDER_ID = 1L;
     private static final int TODAY_GOAL_COUNT = 10;
+    private static final ZoneId SERVICE_ZONE = ZoneId.of("Asia/Seoul");
 
     private final DailyStatRepository dailyStatRepository;
     private final FolderRepository folderRepository;
     private final ProblemRepository problemRepository;
+    private final LearningProgressRepository learningProgressRepository;
 
     @Override
     public HomeResponse.GetHomeResponse getHome() {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(SERVICE_ZONE);
 
         DailyStat todayStat = dailyStatRepository.findByStatDate(today).orElse(null);
 
@@ -52,7 +57,7 @@ public class HomeQueryServiceImpl implements HomeQueryService {
             totalSolvedCount = 0;
         }
 
-        int level = calculateLevel(totalSolvedCount);
+        int level = getCurrentLevel();
 
         HomeResponse.AchievementCard achievementCard = HomeConverter.toAchievementCard(
                 todayFocusSeconds,
@@ -72,6 +77,13 @@ public class HomeQueryServiceImpl implements HomeQueryService {
                 .toList();
 
         return HomeConverter.toGetHomeResponse(achievementCard, rootFolderItems);
+    }
+
+    private int getCurrentLevel() {
+        return learningProgressRepository
+                .findById(LearningProgress.SINGLE_USER_PROGRESS_KEY)
+                .map(LearningProgress::getLevel)
+                .orElse(1);
     }
 
     private HomeResponse.RootFolderItem toRootFolderItem(Folder folder) {
@@ -97,22 +109,6 @@ public class HomeQueryServiceImpl implements HomeQueryService {
         }
 
         return new FolderStats(total, solved);
-    }
-
-    private int calculateLevel(int totalSolvedCount) {
-        if (totalSolvedCount >= 200) {
-            return 5;
-        }
-        if (totalSolvedCount >= 120) {
-            return 4;
-        }
-        if (totalSolvedCount >= 60) {
-            return 3;
-        }
-        if (totalSolvedCount >= 20) {
-            return 2;
-        }
-        return 1;
     }
 
     private record FolderStats(int total, int solved) {

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/entity/Problem.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/entity/Problem.java
@@ -47,6 +47,9 @@ public class Problem {
     @Column(name = "solved_count")
     private Integer solvedCount;
 
+    @Column(name = "last_practiced_bookmarked_round_no")
+    private Integer lastPracticedBookmarkedRoundNo;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "folder_id", nullable = false)
     private Folder folder;
@@ -100,5 +103,16 @@ public class Problem {
             return;
         }
         this.isBookmarked = !this.isBookmarked;
+    }
+
+    public void markPracticedInBookmarkedRound(Integer roundNo) {
+        if (roundNo == null) {
+            return;
+        }
+
+        if (this.lastPracticedBookmarkedRoundNo == null
+                || this.lastPracticedBookmarkedRoundNo < roundNo) {
+            this.lastPracticedBookmarkedRoundNo = roundNo;
+        }
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
@@ -66,4 +66,7 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
             Pageable pageable
     );
 
+    int countByIsBookmarkedTrue();
+
+    int countByIsBookmarkedTrueAndLastPracticedBookmarkedRoundNo(Integer roundNo);
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
@@ -69,4 +69,44 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
     int countByIsBookmarkedTrue();
 
     int countByIsBookmarkedTrueAndLastPracticedBookmarkedRoundNo(Integer roundNo);
+
+    @Query("""
+            select distinct f
+            from Problem p
+            join p.folder f
+            where p.isBookmarked = true
+              and (
+                  p.lastPracticedBookmarkedRoundNo is null
+                  or p.lastPracticedBookmarkedRoundNo < :currentRoundNo
+              )
+              and not exists (
+                  select 1
+                  from Folder child
+                  where child.parentFolder = f
+              )
+            order by f.folderId asc
+            """)
+    List<Folder> findLeafFoldersHavingUnpracticedBookmarkedProblemsInRound(
+            @Param("currentRoundNo") Integer currentRoundNo
+    );
+
+    @Query("""
+            select p
+            from Problem p
+            join fetch p.folder f
+            where f.folderId = :folderId
+              and p.isBookmarked = true
+              and (
+                  p.lastPracticedBookmarkedRoundNo is null
+                  or p.lastPracticedBookmarkedRoundNo < :currentRoundNo
+              )
+            order by coalesce(p.solvedCount, 0) asc,
+                     p.problemNum asc,
+                     p.problemId asc
+            """)
+    List<Problem> findUnpracticedBookmarkedProblemsByFolderIdForPractice(
+            @Param("folderId") Long folderId,
+            @Param("currentRoundNo") Integer currentRoundNo,
+            Pageable pageable
+    );
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemCommandServiceImpl.java
@@ -16,6 +16,8 @@ import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportRequest;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
 import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
+import com.hhd1337.jatuli_quiz.domain.progress.entity.LearningProgress;
+import com.hhd1337.jatuli_quiz.domain.progress.repository.LearningProgressRepository;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +36,7 @@ public class ProblemCommandServiceImpl implements ProblemCommandService {
     private final FolderRepository folderRepository;
     private final ProblemTextParser problemTextParser;
     private final PracticeCursorRepository practiceCursorRepository;
+    private final LearningProgressRepository learningProgressRepository;
 
     @Override
     public ProblemBookmarkResponse.ToggleBookmarkResponse toggleBookmark(Long problemId) {
@@ -98,9 +101,13 @@ public class ProblemCommandServiceImpl implements ProblemCommandService {
     ) {
         int requestedProblemCount = normalizePracticeProblemCount(request.getProblemCount());
 
+        LearningProgress learningProgress = getOrCreateSingleUserLearningProgress();
+        Integer currentRoundNo = learningProgress.getCurrentBookmarkedRoundNo();
+
         PracticeCursor cursor = getOrCreateBookmarkedPracticeCursor();
 
-        List<Folder> leafFolders = problemRepository.findLeafFoldersHavingBookmarkedProblemsOrderByFolderIdAsc();
+        List<Folder> leafFolders = problemRepository
+                .findLeafFoldersHavingUnpracticedBookmarkedProblemsInRound(currentRoundNo);
 
         if (leafFolders.isEmpty()) {
             throw new GeneralException(ErrorStatus.BOOKMARKED_PROBLEM_NOT_FOUND);
@@ -122,10 +129,12 @@ public class ProblemCommandServiceImpl implements ProblemCommandService {
             int remainingProblemCount = requestedProblemCount - selectedProblems.size();
             int limit = Math.min(FOLDER_PROBLEM_LIMIT, remainingProblemCount);
 
-            List<Problem> problemsInFolder = problemRepository.findBookmarkedProblemsByFolderIdForPractice(
-                    leafFolder.getFolderId(),
-                    PageRequest.of(0, limit)
-            );
+            List<Problem> problemsInFolder = problemRepository
+                    .findUnpracticedBookmarkedProblemsByFolderIdForPractice(
+                            leafFolder.getFolderId(),
+                            currentRoundNo,
+                            PageRequest.of(0, limit)
+                    );
 
             if (!problemsInFolder.isEmpty()) {
                 selectedProblems.addAll(problemsInFolder);
@@ -147,16 +156,23 @@ public class ProblemCommandServiceImpl implements ProblemCommandService {
         );
     }
 
-    private int normalizePracticeProblemCount(Integer size) {
-        if (size == null) {
+    private int normalizePracticeProblemCount(Integer problemCount) {
+        if (problemCount == null) {
             return 10;
         }
 
-        if (size < 1) {
+        if (problemCount < 1) {
             return 10;
         }
 
-        return Math.min(size, 50);
+        return Math.min(problemCount, 50);
+    }
+
+    private LearningProgress getOrCreateSingleUserLearningProgress() {
+        return learningProgressRepository.findById(LearningProgress.SINGLE_USER_PROGRESS_KEY)
+                .orElseGet(() -> learningProgressRepository.save(
+                        LearningProgress.createSingleUserProgress()
+                ));
     }
 
     private PracticeCursor getOrCreateBookmarkedPracticeCursor() {

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/service/ProblemSubmissionCommandServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/service/ProblemSubmissionCommandServiceImpl.java
@@ -11,8 +11,11 @@ import com.hhd1337.jatuli_quiz.domain.problemsubmission.dto.ProblemSubmissionReq
 import com.hhd1337.jatuli_quiz.domain.problemsubmission.dto.ProblemSubmissionResponse;
 import com.hhd1337.jatuli_quiz.domain.problemsubmission.entity.ProblemSubmission;
 import com.hhd1337.jatuli_quiz.domain.problemsubmission.repository.ProblemSubmissionRepository;
+import com.hhd1337.jatuli_quiz.domain.progress.entity.LearningProgress;
+import com.hhd1337.jatuli_quiz.domain.progress.repository.LearningProgressRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,9 +26,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ProblemSubmissionCommandServiceImpl implements ProblemSubmissionCommandService {
 
+    private static final ZoneId SERVICE_ZONE = ZoneId.of("Asia/Seoul");
+
     private final ProblemRepository problemRepository;
     private final ProblemSubmissionRepository problemSubmissionRepository;
     private final DailyStatRepository dailyStatRepository;
+    private final LearningProgressRepository learningProgressRepository;
 
     @Override
     public ProblemSubmissionResponse.CreateProblemSubmissionResponse submit(
@@ -34,25 +40,68 @@ public class ProblemSubmissionCommandServiceImpl implements ProblemSubmissionCom
         Problem problem = problemRepository.findById(request.getProblemId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PROBLEM_NOT_FOUND));
 
+        LearningProgress learningProgress = getOrCreateSingleUserLearningProgressWithLock();
+        Integer currentRoundNo = learningProgress.getCurrentBookmarkedRoundNo();
+
         int elapsedSeconds = request.getElapsedSeconds() == null ? 0 : request.getElapsedSeconds();
 
+        boolean isBookmarkedSubmission = Boolean.TRUE.equals(problem.getIsBookmarked());
+
         problem.increaseSolvedCount();
+
+        if (isBookmarkedSubmission) {
+            problem.markPracticedInBookmarkedRound(currentRoundNo);
+        }
 
         ProblemSubmission submission = new ProblemSubmission(
                 problem,
                 request.getIsCorrect(),
                 elapsedSeconds,
-                LocalDateTime.now()
+                LocalDateTime.now(SERVICE_ZONE)
         );
         problemSubmissionRepository.save(submission);
 
         DailyStat dailyStat = updateDailyStat(elapsedSeconds);
 
+        if (isBookmarkedSubmission) {
+            problemRepository.flush();
+            completeBookmarkedRoundIfNeeded(learningProgress, currentRoundNo);
+        }
+
         return ProblemSubmissionConverter.toCreateProblemSubmissionResponse(problem, dailyStat);
     }
 
+    private LearningProgress getOrCreateSingleUserLearningProgressWithLock() {
+        return learningProgressRepository.findByIdWithLock(LearningProgress.SINGLE_USER_PROGRESS_KEY)
+                .orElseGet(() -> learningProgressRepository.save(
+                        LearningProgress.createSingleUserProgress()
+                ));
+    }
+
+    private void completeBookmarkedRoundIfNeeded(
+            LearningProgress learningProgress,
+            Integer currentRoundNo
+    ) {
+        if (currentRoundNo == null) {
+            return;
+        }
+
+        int totalBookmarkedProblemCount = problemRepository.countByIsBookmarkedTrue();
+
+        if (totalBookmarkedProblemCount == 0) {
+            return;
+        }
+
+        int practicedBookmarkedProblemCount =
+                problemRepository.countByIsBookmarkedTrueAndLastPracticedBookmarkedRoundNo(currentRoundNo);
+
+        if (practicedBookmarkedProblemCount >= totalBookmarkedProblemCount) {
+            learningProgress.completeCurrentBookmarkedRound();
+        }
+    }
+
     private DailyStat updateDailyStat(int elapsedSeconds) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(SERVICE_ZONE);
 
         Optional<DailyStat> todayStatOptional = dailyStatRepository.findByStatDate(today);
 

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/progress/entity/LearningProgress.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/progress/entity/LearningProgress.java
@@ -1,0 +1,67 @@
+package com.hhd1337.jatuli_quiz.domain.progress.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "learning_progress")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LearningProgress {
+
+    public static final String SINGLE_USER_PROGRESS_KEY = "SINGLE_USER";
+
+    @Id
+    @Column(name = "progress_key", length = 50)
+    private String progressKey;
+
+    @Column(name = "completed_bookmarked_round_count", nullable = false)
+    private Integer completedBookmarkedRoundCount;
+
+    @Column(name = "current_bookmarked_round_no", nullable = false)
+    private Integer currentBookmarkedRoundNo;
+
+    private LearningProgress(
+            String progressKey,
+            Integer completedBookmarkedRoundCount,
+            Integer currentBookmarkedRoundNo
+    ) {
+        this.progressKey = progressKey;
+        this.completedBookmarkedRoundCount = completedBookmarkedRoundCount;
+        this.currentBookmarkedRoundNo = currentBookmarkedRoundNo;
+    }
+
+    public static LearningProgress createSingleUserProgress() {
+        return new LearningProgress(
+                SINGLE_USER_PROGRESS_KEY,
+                0,
+                1
+        );
+    }
+
+    public void completeCurrentBookmarkedRound() {
+        if (this.completedBookmarkedRoundCount == null) {
+            this.completedBookmarkedRoundCount = 0;
+        }
+
+        if (this.currentBookmarkedRoundNo == null) {
+            this.currentBookmarkedRoundNo = 1;
+        }
+
+        this.completedBookmarkedRoundCount += 1;
+        this.currentBookmarkedRoundNo += 1;
+    }
+
+    public int getLevel() {
+        if (this.completedBookmarkedRoundCount == null) {
+            return 1;
+        }
+
+        return this.completedBookmarkedRoundCount + 1;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/progress/repository/LearningProgressRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/progress/repository/LearningProgressRepository.java
@@ -1,0 +1,20 @@
+package com.hhd1337.jatuli_quiz.domain.progress.repository;
+
+import com.hhd1337.jatuli_quiz.domain.progress.entity.LearningProgress;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface LearningProgressRepository extends JpaRepository<LearningProgress, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select lp
+            from LearningProgress lp
+            where lp.progressKey = :progressKey
+            """)
+    Optional<LearningProgress> findByIdWithLock(@Param("progressKey") String progressKey);
+}


### PR DESCRIPTION
## 📝 작업 내용 설명

홈 화면의 Level 계산 기준을 기존 전체 풀이 횟수 기반에서 북마크 문제 전체 순회 완료 횟수 기반으로 변경했습니다.

기존에는 `Problem.solvedCount` 합계를 기준으로 Level을 계산했지만, 서비스의 핵심 흐름은 사용자가 북마크한 문제들을 반복 순회하며 숙달하는 방식입니다.  
따라서 이번 PR에서는 북마크된 문제 전체를 하나의 라운드로 보고, 현재 라운드에서 모든 북마크 문제가 제출되면 전체 순회 1회 완료로 판단하도록 수정했습니다.

이를 위해 단일 사용자 학습 진행도 엔티티를 추가하고, 문제별로 마지막으로 풀이 완료된 북마크 라운드 번호를 기록하도록 변경했습니다.


## ✅ 작업 내용

- [x] 단일 사용자 학습 진행도 `LearningProgress` 엔티티 추가
- [x] 문제별 북마크 순회 라운드 풀이 상태 필드 추가
- [x] 북마크 문제 순회 API 후보를 현재 라운드 미풀이 문제 기준으로 변경
- [x] 문제 제출 시 현재 북마크 라운드 풀이 상태 반영
- [x] 모든 북마크 문제가 현재 라운드에서 제출되면 전체 순회 완료 처리
- [x] 홈 Level 계산 기준을 북마크 순회 완료 횟수 기반으로 변경


## 🔍 주요 변경 포인트

- `LearningProgress`를 통해 `currentBookmarkedRoundNo`, `completedBookmarkedRoundCount`를 관리합니다.
- `Problem.lastPracticedBookmarkedRoundNo`를 추가하여 문제가 마지막으로 풀이 완료된 북마크 라운드를 기록합니다.
- `POST /problems/bookmarked/practice`는 이제 현재 라운드에서 아직 제출되지 않은 북마크 문제만 제공합니다.
- `POST /problem-submissions` 호출 시 북마크된 문제라면 현재 라운드에서 풀이 완료된 것으로 기록합니다.
- 현재 북마크된 모든 문제가 현재 라운드에서 제출되면 완료 라운드 수를 증가시키고 다음 라운드로 넘어갑니다.
- `GET /home`의 Level은 `completedBookmarkedRoundCount + 1` 기준으로 계산됩니다.


## 🧪 확인한 내용

- [x] 로컬 환경에서 정상 동작 확인
- [x] API 요청/응답 확인
- [x] 북마크 문제 순회 API에서 현재 라운드 미풀이 문제만 반환되는지 확인
- [x] 문제 제출 시 `solvedCount`와 라운드 풀이 상태가 함께 갱신되는지 확인
- [x] 모든 북마크 문제 제출 완료 시 Level이 증가하는지 확인
- [x] 다음 라운드에서 기존 문제가 다시 순회 대상에 포함되는지 확인


## 📌 비고

현재 서비스는 단일 사용자 MVP 기준이므로 `Member` 테이블은 추가하지 않고, `LearningProgress`를 전역 학습 진행도로 관리합니다.

이번 방식은 라운드 시작 시점의 북마크 문제 목록을 별도 스냅샷으로 고정하지 않습니다. 따라서 라운드 진행 중 새로 추가된 북마크 문제도 현재 라운드 완료 대상에 포함됩니다.

향후 다중 사용자 기능이 추가되면 `LearningProgress`와 문제별 라운드 풀이 상태는 사용자별 진행도/문제 상태 테이블로 분리할 수 있습니다.


## 🔗 관련 이슈

closes #50