### PR TITLE
feat: 북마크 문제 전체순회 진행률 UI 및 풀이 모드 연동

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/converter/HomeConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/converter/HomeConverter.java
@@ -31,6 +31,27 @@ public class HomeConverter {
                 .build();
     }
 
+    public static HomeResponse.BookmarkCycleProgress toBookmarkCycleProgress(
+            int currentBookmarkedRoundNo,
+            int totalBookmarkedProblemCount,
+            int currentCycleSolvedProblemCount
+    ) {
+        int safeCurrentRoundNo = Math.max(1, currentBookmarkedRoundNo);
+        int safeTotalCount = Math.max(0, totalBookmarkedProblemCount);
+        int safeSolvedCount = Math.max(0, Math.min(currentCycleSolvedProblemCount, safeTotalCount));
+
+        int progressPercent = safeTotalCount == 0
+                ? 0
+                : (int) Math.floor((safeSolvedCount * 100.0) / safeTotalCount);
+
+        return HomeResponse.BookmarkCycleProgress.builder()
+                .currentBookmarkedRoundNo(safeCurrentRoundNo)
+                .totalBookmarkedProblemCount(safeTotalCount)
+                .currentCycleSolvedProblemCount(safeSolvedCount)
+                .progressPercent(progressPercent)
+                .build();
+    }
+
     public static HomeResponse.RootFolderItem toRootFolderItem(
             Folder folder,
             int solvedProblemCount,
@@ -46,10 +67,12 @@ public class HomeConverter {
 
     public static HomeResponse.GetHomeResponse toGetHomeResponse(
             HomeResponse.AchievementCard achievementCard,
+            HomeResponse.BookmarkCycleProgress bookmarkCycleProgress,
             List<HomeResponse.RootFolderItem> rootFolders
     ) {
         return HomeResponse.GetHomeResponse.builder()
                 .achievementCard(achievementCard)
+                .bookmarkCycleProgress(bookmarkCycleProgress)
                 .rootFolders(rootFolders)
                 .build();
     }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/dto/HomeResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/dto/HomeResponse.java
@@ -12,6 +12,7 @@ public class HomeResponse {
     @AllArgsConstructor
     public static class GetHomeResponse {
         private AchievementCard achievementCard;
+        private BookmarkCycleProgress bookmarkCycleProgress;
         private List<RootFolderItem> rootFolders;
     }
 
@@ -27,6 +28,16 @@ public class HomeResponse {
         private Integer level;
         private Integer todayGoalCount;
         private Integer todayGoalSolvedCount;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class BookmarkCycleProgress {
+        private Integer currentBookmarkedRoundNo;
+        private Integer totalBookmarkedProblemCount;
+        private Integer currentCycleSolvedProblemCount;
+        private Integer progressPercent;
     }
 
     @Getter

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/service/HomeQueryServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/service/HomeQueryServiceImpl.java
@@ -35,6 +35,7 @@ public class HomeQueryServiceImpl implements HomeQueryService {
         LocalDate today = LocalDate.now(SERVICE_ZONE);
 
         DailyStat todayStat = dailyStatRepository.findByStatDate(today).orElse(null);
+        LearningProgress learningProgress = getLearningProgressOrNull();
 
         int todayFocusSeconds = todayStat == null || todayStat.getFocusSeconds() == null
                 ? 0
@@ -57,7 +58,7 @@ public class HomeQueryServiceImpl implements HomeQueryService {
             totalSolvedCount = 0;
         }
 
-        int level = getCurrentLevel();
+        int level = getCurrentLevel(learningProgress);
 
         HomeResponse.AchievementCard achievementCard = HomeConverter.toAchievementCard(
                 todayFocusSeconds,
@@ -70,20 +71,61 @@ public class HomeQueryServiceImpl implements HomeQueryService {
                 todaySolvedCount
         );
 
+        HomeResponse.BookmarkCycleProgress bookmarkCycleProgress =
+                getBookmarkCycleProgress(learningProgress);
+
         List<Folder> rootFolders = folderRepository.findAllByParentFolder_FolderIdOrderByFolderIdAsc(ROOT_FOLDER_ID);
 
         List<HomeResponse.RootFolderItem> rootFolderItems = rootFolders.stream()
                 .map(this::toRootFolderItem)
                 .toList();
 
-        return HomeConverter.toGetHomeResponse(achievementCard, rootFolderItems);
+        return HomeConverter.toGetHomeResponse(
+                achievementCard,
+                bookmarkCycleProgress,
+                rootFolderItems
+        );
     }
 
-    private int getCurrentLevel() {
+    private LearningProgress getLearningProgressOrNull() {
         return learningProgressRepository
                 .findById(LearningProgress.SINGLE_USER_PROGRESS_KEY)
-                .map(LearningProgress::getLevel)
-                .orElse(1);
+                .orElse(null);
+    }
+
+    private int getCurrentLevel(LearningProgress learningProgress) {
+        if (learningProgress == null) {
+            return 1;
+        }
+
+        return learningProgress.getLevel();
+    }
+
+    private int getCurrentBookmarkedRoundNo(LearningProgress learningProgress) {
+        if (learningProgress == null || learningProgress.getCurrentBookmarkedRoundNo() == null) {
+            return 1;
+        }
+
+        return learningProgress.getCurrentBookmarkedRoundNo();
+    }
+
+    private HomeResponse.BookmarkCycleProgress getBookmarkCycleProgress(
+            LearningProgress learningProgress
+    ) {
+        int currentBookmarkedRoundNo = getCurrentBookmarkedRoundNo(learningProgress);
+
+        int totalBookmarkedProblemCount = problemRepository.countByIsBookmarkedTrue();
+
+        int currentCycleSolvedProblemCount =
+                problemRepository.countByIsBookmarkedTrueAndLastPracticedBookmarkedRoundNoGreaterThanEqual(
+                        currentBookmarkedRoundNo
+                );
+
+        return HomeConverter.toBookmarkCycleProgress(
+                currentBookmarkedRoundNo,
+                totalBookmarkedProblemCount,
+                currentCycleSolvedProblemCount
+        );
     }
 
     private HomeResponse.RootFolderItem toRootFolderItem(Folder folder) {

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/problems")
+@RequestMapping("api/v1/problems")
 @RequiredArgsConstructor
 public class ProblemRestController {
 

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
@@ -109,4 +109,6 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
             @Param("currentRoundNo") Integer currentRoundNo,
             Pageable pageable
     );
+
+    int countByIsBookmarkedTrueAndLastPracticedBookmarkedRoundNoGreaterThanEqual(Integer roundNo);
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,4 +1,3 @@
-import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import "./index.css";
@@ -6,7 +5,5 @@ import "./index.css";
 import { router } from "./app/router";
 
 createRoot(document.getElementById("root")).render(
-  <StrictMode>
     <RouterProvider router={router} />
-  </StrictMode>
 );

--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -57,6 +57,16 @@ export default function HomePage() {
 
     const { summary, rootFolders, quickActions } = homeData;
 
+    const randomAction = quickActions.find((action) => action.key === "RANDOM");
+    const bookmarkAction = quickActions.find((action) => action.key === "BOOKMARK");
+
+    const bookmarkCycle = summary.bookmarkCycle;
+    const bookmarkSolvedCount = bookmarkCycle.currentCycleSolvedProblemCount;
+    const bookmarkTotalCount = bookmarkCycle.totalBookmarkedProblemCount;
+    const bookmarkProgressPercent = bookmarkCycle.progressPercent;
+    const currentBookmarkedRoundNo = bookmarkCycle.currentBookmarkedRoundNo;
+    const hasBookmarkProblems = bookmarkTotalCount > 0;
+
     return (
         <div style={{ maxWidth: 800, margin: "0 auto" }}>
             <h1>자투리 퀴즈 홈</h1>
@@ -77,9 +87,118 @@ export default function HomePage() {
                 <div>📚 누적 푼 문제 수: {summary.solvedCountTotal}문제</div>
                 <div>🕒 오늘 자투리 시간 저축: {summary.todayFocusTimeText}</div>
                 <div>✅ 오늘 푼 문제 수: {summary.todaySolvedCount}문제</div>
-                <div>🌱 Level {summary.level} ({summary.solvedCountTotal}문제 해결)</div>
                 <div>🔥 {summary.streakDays}일 연속 도전 중</div>
-                <div>🎯 오늘 목표 {summary.todayGoal.solvedCount}/{summary.todayGoal.goalCount}</div>
+                <div>
+                    🎯 오늘 목표 {summary.todayGoal.solvedCount}/{summary.todayGoal.goalCount}
+                </div>
+            </div>
+
+            {/* ================== 빠른 실행 ================== */}
+            <div style={{ marginBottom: 32 }}>
+                <h2>빠른 실행</h2>
+
+                {randomAction && (
+                    <button
+                        type="button"
+                        onClick={() => navigate("/quiz/play?mode=random")}
+                        style={{
+                            marginBottom: 16,
+                            padding: "6px 12px",
+                            cursor: "pointer",
+                        }}
+                    >
+                        🎲 {randomAction.label}
+                    </button>
+                )}
+
+                <div
+                    style={{
+                        border: "1px solid #ddd",
+                        borderRadius: 12,
+                        padding: 16,
+                        marginTop: 8,
+                    }}
+                >
+                    <div
+                        style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                            gap: 12,
+                            marginBottom: 8,
+                        }}
+                    >
+                        <h3 style={{ margin: 0 }}>📦 북마크 문제 전체 순회</h3>
+                        <strong>Level {summary.level}</strong>
+                    </div>
+
+                    <p style={{ marginTop: 0, marginBottom: 8, color: "#555" }}>
+                        북마크된 모든 문제를 한 바퀴 다 풀면 레벨이 1 증가합니다.
+                    </p>
+
+                    <p style={{ marginTop: 0, marginBottom: 12, color: "#777", fontSize: 14 }}>
+                        현재 북마크 순회 라운드: {currentBookmarkedRoundNo}회차
+                    </p>
+
+                    <div
+                        style={{
+                            width: "100%",
+                            height: 14,
+                            backgroundColor: "#eee",
+                            borderRadius: 999,
+                            overflow: "hidden",
+                            marginBottom: 8,
+                        }}
+                        role="progressbar"
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-valuenow={bookmarkProgressPercent}
+                        aria-label="북마크 문제 전체 순회 진행률"
+                    >
+                        <div
+                            style={{
+                                width: `${bookmarkProgressPercent}%`,
+                                height: "100%",
+                                backgroundColor: "#22c55e",
+                                transition: "width 0.2s ease",
+                            }}
+                        />
+                    </div>
+
+                    <div
+                        style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                            marginBottom: 12,
+                            fontSize: 14,
+                        }}
+                    >
+                        <span>
+                            진행률 {bookmarkSolvedCount}/{bookmarkTotalCount}
+                        </span>
+                        <span>{bookmarkProgressPercent}%</span>
+                    </div>
+
+                    <button
+                        type="button"
+                        onClick={() => navigate("/quiz/play?mode=bookmark")}
+                        disabled={!hasBookmarkProblems}
+                        style={{
+                            padding: "6px 12px",
+                            cursor: hasBookmarkProblems ? "pointer" : "not-allowed",
+                            opacity: hasBookmarkProblems ? 1 : 0.5,
+                        }}
+                    >
+                        📦 {bookmarkAction?.label ?? "북마크 문제 전체순회"}
+                    </button>
+
+                    {!hasBookmarkProblems && (
+                        <p style={{ marginBottom: 0, color: "#777", fontSize: 14 }}>
+                            현재 북마크된 문제가 없습니다.
+                        </p>
+                    )}
+                </div>
             </div>
 
             {/* ================== 폴더 리스트 ================== */}
@@ -104,38 +223,6 @@ export default function HomePage() {
                     ))}
                 </ul>
             )}
-
-            {/* ================== 빠른 실행 ================== */}
-            <div style={{ marginTop: 32 }}>
-                <h2>빠른 실행</h2>
-
-                {quickActions.map((action) => {
-                    if (action.key === "RANDOM") {
-                        return (
-                            <button
-                                key={action.key}
-                                onClick={() => navigate("/quiz/play?mode=random")}
-                                style={{ marginRight: 8 }}
-                            >
-                                🎲 {action.label}
-                            </button>
-                        );
-                    }
-
-                    if (action.key === "BOOKMARK") {
-                        return (
-                            <button
-                                key={action.key}
-                                onClick={() => navigate("/quiz/play?mode=bookmark")}
-                            >
-                                📦 {action.label}
-                            </button>
-                        );
-                    }
-
-                    return null;
-                })}
-            </div>
         </div>
     );
 }

--- a/frontend/src/pages/quiz/QuizPlayPage.jsx
+++ b/frontend/src/pages/quiz/QuizPlayPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { getFolderPractice } from "../../shared/api/folderApi";
+import { getBookmarkedPractice } from "../../shared/api/quizApi";
 import FabGroup from "../../features/fab/FabGroup";
 
 export default function QuizPlayPage() {
@@ -11,12 +12,16 @@ export default function QuizPlayPage() {
     const folderId = searchParams.get("folderId");
     const mode = searchParams.get("mode");
 
+    const isBookmarkMode = mode === "bookmark";
+    const isRandomMode = mode === "random";
+    const isUnsupportedMode = !!mode && !isBookmarkMode && !isRandomMode;
+
     const initialTitlePath = location.state?.titlePath ?? "";
     const parentFolderId = location.state?.parentFolderId ?? null;
 
     const [isMusicOn, setIsMusicOn] = useState(false);
     const [localProblems, setLocalProblems] = useState([]);
-    const [loading, setLoading] = useState(false);
+    const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
     const [titlePath, setTitlePath] = useState(initialTitlePath);
     const [showCompleteScreen, setShowCompleteScreen] = useState(false);
@@ -27,36 +32,77 @@ export default function QuizPlayPage() {
     const problems = localProblems;
 
     useEffect(() => {
-        async function fetchPracticeProblems() {
-            if (!folderId) return;
+        let ignore = false;
 
+        async function fetchPracticeProblems() {
             try {
                 setLoading(true);
                 setError("");
+                setLocalProblems([]);
                 setShowCompleteScreen(false);
-
-                const data = await getFolderPractice(folderId);
-                setLocalProblems(data.problems ?? []);
-
-                if (data.titlePath) {
-                    setTitlePath(data.titlePath);
-                }
-
                 setCurrentIndex(0);
                 setShowAnswer(false);
+
+                if (isBookmarkMode) {
+                    const data = await getBookmarkedPractice();
+
+                    if (ignore) return;
+
+                    setLocalProblems(data.problems ?? []);
+                    setTitlePath(data.titlePath ?? "북마크 문제 전체 순회");
+                    return;
+                }
+
+                if (isRandomMode) {
+                    setError("랜덤 문제 풀기는 아직 별도 연동 전입니다.");
+                    setTitlePath("랜덤 문제 풀기");
+                    return;
+                }
+
+                if (isUnsupportedMode) {
+                    setError(`지원하지 않는 문제 풀이 모드입니다: ${mode}`);
+                    setTitlePath("QuizPlayPage");
+                    return;
+                }
+
+                if (!folderId) {
+                    setError("folderId가 없습니다. leaf 폴더에서 진입해주세요.");
+                    setTitlePath("QuizPlayPage");
+                    return;
+                }
+
+                const data = await getFolderPractice(folderId);
+
+                if (ignore) return;
+
+                setLocalProblems(data.problems ?? []);
+                setTitlePath(data.titlePath || `폴더 ${folderId}`);
             } catch (err) {
+                if (ignore) return;
+
                 console.error("연습 문제 조회 실패:", err);
                 setError("문제 목록을 불러오지 못했습니다.");
                 setLocalProblems([]);
             } finally {
-                setLoading(false);
+                if (!ignore) {
+                    setLoading(false);
+                }
             }
         }
 
         fetchPracticeProblems();
-    }, [folderId]);
 
-    const handleExitFolder = () => {
+        return () => {
+            ignore = true;
+        };
+    }, [folderId, mode, isBookmarkMode, isRandomMode, isUnsupportedMode]);
+
+    const handleExit = () => {
+        if (isBookmarkMode || isRandomMode || isUnsupportedMode) {
+            navigate("/");
+            return;
+        }
+
         if (parentFolderId) {
             navigate(`/folders/${parentFolderId}`);
             return;
@@ -65,30 +111,38 @@ export default function QuizPlayPage() {
         navigate(-1);
     };
 
-    if (!folderId) {
-        return (
-            <div style={{ maxWidth: 800, margin: "0 auto" }}>
-                <h1>QuizPlayPage</h1>
-                <p>folderId가 없습니다. leaf 폴더에서 진입해주세요.</p>
-                <p style={{ opacity: 0.7 }}>
-                    예: <code>/quiz/play?folderId=9</code>
-                </p>
+    const getExitButtonText = () => {
+        if (isBookmarkMode || isRandomMode || isUnsupportedMode) {
+            return "홈으로";
+        }
 
-                {mode && (
-                    <p style={{ opacity: 0.7 }}>
-                        mode=<code>{mode}</code> 는 아직 별도 연동 전입니다.
-                    </p>
-                )}
+        return "폴더 나가기";
+    };
 
-                <button onClick={() => navigate("/")}>홈으로</button>
-            </div>
-        );
-    }
+    const getEmptyMessage = () => {
+        if (isBookmarkMode) {
+            return "이번 북마크 순회에서 풀 문제가 없습니다.";
+        }
+
+        if (isRandomMode) {
+            return "랜덤 문제를 불러올 수 없습니다.";
+        }
+
+        return "이 폴더에는 문제가 없습니다.";
+    };
+
+    const getCompleteMessage = () => {
+        if (isBookmarkMode) {
+            return "이번 북마크 순회에서 불러온 문제를 모두 확인했어요.";
+        }
+
+        return "이 폴더의 문제를 끝까지 모두 확인했어요.";
+    };
 
     if (loading) {
         return (
             <div style={{ maxWidth: 800, margin: "0 auto" }}>
-                <h1 style={{ margin: 0 }}>{titlePath || `폴더 ${folderId}`}</h1>
+                <h1 style={{ margin: 0 }}>{titlePath || "QuizPlayPage"}</h1>
                 <p>문제를 불러오는 중...</p>
             </div>
         );
@@ -97,9 +151,16 @@ export default function QuizPlayPage() {
     if (error) {
         return (
             <div style={{ maxWidth: 800, margin: "0 auto" }}>
-                <h1 style={{ margin: 0 }}>{titlePath || `폴더 ${folderId}`}</h1>
+                <h1 style={{ margin: 0 }}>{titlePath || "QuizPlayPage"}</h1>
                 <p>{error}</p>
-                <button onClick={handleExitFolder}>폴더 나가기</button>
+
+                {!isBookmarkMode && !isRandomMode && !isUnsupportedMode && !folderId && (
+                    <p style={{ opacity: 0.7 }}>
+                        예: <code>/quiz/play?folderId=9</code>
+                    </p>
+                )}
+
+                <button onClick={handleExit}>{getExitButtonText()}</button>
             </div>
         );
     }
@@ -107,9 +168,9 @@ export default function QuizPlayPage() {
     if (problems.length === 0) {
         return (
             <div style={{ maxWidth: 800, margin: "0 auto" }}>
-                <h1 style={{ margin: 0 }}>{titlePath || `폴더 ${folderId}`}</h1>
-                <p>이 폴더에는 문제가 없습니다.</p>
-                <button onClick={handleExitFolder}>폴더 나가기</button>
+                <h1 style={{ margin: 0 }}>{titlePath || "QuizPlayPage"}</h1>
+                <p>{getEmptyMessage()}</p>
+                <button onClick={handleExit}>{getExitButtonText()}</button>
             </div>
         );
     }
@@ -131,10 +192,8 @@ export default function QuizPlayPage() {
             >
                 <div style={{ fontSize: 64 }}>🎉</div>
                 <h1 style={{ margin: 0 }}>모두 풀었습니다!</h1>
-                <p style={{ opacity: 0.8 }}>
-                    이 폴더의 문제를 끝까지 모두 확인했어요.
-                </p>
-                <button onClick={handleExitFolder}>폴더 목록으로 돌아가기</button>
+                <p style={{ opacity: 0.8 }}>{getCompleteMessage()}</p>
+                <button onClick={handleExit}>{getExitButtonText()}</button>
             </div>
         );
     }
@@ -195,7 +254,7 @@ export default function QuizPlayPage() {
                     alignItems: "baseline",
                 }}
             >
-                <h1 style={{ margin: 0 }}>{titlePath || `폴더 ${folderId}`}</h1>
+                <h1 style={{ margin: 0 }}>{titlePath || "QuizPlayPage"}</h1>
                 <div style={{ opacity: 0.7 }}>
                     {currentIndex + 1} / {problems.length}
                 </div>
@@ -233,7 +292,7 @@ export default function QuizPlayPage() {
                     이전 문제
                 </button>
                 <button onClick={goNext}>다음 문제</button>
-                <button onClick={handleExitFolder}>폴더 나가기</button>
+                <button onClick={handleExit}>{getExitButtonText()}</button>
             </div>
 
             {showAnswer && (

--- a/frontend/src/shared/api/folderApi.js
+++ b/frontend/src/shared/api/folderApi.js
@@ -1,5 +1,15 @@
 import { apiClient } from "./client";
 
+function toNonNegativeNumber(value, fallback = 0) {
+    const numberValue = Number(value);
+
+    if (!Number.isFinite(numberValue)) {
+        return fallback;
+    }
+
+    return Math.max(0, Math.floor(numberValue));
+}
+
 function normalizeFolderChildren(raw) {
     const breadcrumb = Array.isArray(raw?.breadcrumb) ? raw.breadcrumb : [];
     const folders = Array.isArray(raw?.folders) ? raw.folders : [];
@@ -20,9 +30,15 @@ function normalizeFolderChildren(raw) {
                 children: folders.map((folder) => ({
                     folderId: folder.folderId,
                     name: folder.name ?? "",
-                    solvedCount: folder.solved ?? 0,
-                    totalCount: folder.total ?? 0,
-                    isLeaf: !folder.hasChildren,
+                    solvedCount: toNonNegativeNumber(
+                        folder.solvedProblemCount ?? folder.solved,
+                        0
+                    ),
+                    totalCount: toNonNegativeNumber(
+                        folder.totalProblemCount ?? folder.total,
+                        0
+                    ),
+                    isLeaf: folder.isLeaf ?? !folder.hasChildren,
                 })),
             },
         ],
@@ -44,25 +60,46 @@ function normalizeExplanationToBlocks(explanation) {
         }));
 }
 
+function normalizePracticeProblem(problem, index) {
+    const explanation =
+        problem?.explanation ??
+        problem?.explanationText ??
+        "";
+
+    return {
+        problemId: problem?.problemId ?? null,
+        questionNo: problem?.questionNo ?? problem?.problemNum ?? index + 1,
+        questionText: problem?.question ?? problem?.questionText ?? "",
+        questionImages: Array.isArray(problem?.questionImages)
+            ? problem.questionImages
+            : [],
+        answerText: problem?.answer ?? problem?.answerText ?? "",
+        explanationBlocks: Array.isArray(problem?.explanationBlocks)
+            ? problem.explanationBlocks
+            : normalizeExplanationToBlocks(explanation),
+        meta: {
+            attemptCount: toNonNegativeNumber(
+                problem?.meta?.attemptCount ?? problem?.solvedCount,
+                0
+            ),
+            isBookmarked:
+                problem?.meta?.isBookmarked ??
+                problem?.isBookmarked ??
+                false,
+        },
+    };
+}
+
 function normalizePracticeResponse(raw, folderId) {
+    const problems = Array.isArray(raw?.problems) ? raw.problems : [];
+
     return {
         folderId: Number(folderId),
-        titlePath: "",
+        titlePath: raw?.titlePath ?? raw?.folderPath ?? "",
         selectionRule: raw?.selectionRule ?? "ALL",
-        problems: Array.isArray(raw?.problems)
-            ? raw.problems.map((problem) => ({
-                problemId: problem?.problemId ?? null,
-                questionNo: problem?.problemNum ?? 0,
-                questionText: problem?.question ?? "",
-                questionImages: [],
-                answerText: problem?.answer ?? "",
-                explanationBlocks: normalizeExplanationToBlocks(problem?.explanation),
-                meta: {
-                    attemptCount: problem?.meta?.attemptCount ?? 0,
-                    isBookmarked: problem?.meta?.isBookmarked ?? false,
-                },
-            }))
-            : [],
+        problems: problems.map((problem, index) =>
+            normalizePracticeProblem(problem, index)
+        ),
     };
 }
 

--- a/frontend/src/shared/api/homeApi.js
+++ b/frontend/src/shared/api/homeApi.js
@@ -1,7 +1,7 @@
 import { apiClient } from "./client";
 
 function formatSecondsToKoreanTime(totalSeconds) {
-    const safeSeconds = Math.max(0, Number(totalSeconds) || 0);
+    const safeSeconds = Math.max(0, Math.floor(Number(totalSeconds) || 0));
 
     const hours = Math.floor(safeSeconds / 3600);
     const minutes = Math.floor((safeSeconds % 3600) / 60);
@@ -12,9 +12,11 @@ function formatSecondsToKoreanTime(totalSeconds) {
     if (hours > 0) {
         parts.push(`${hours}시간`);
     }
+
     if (minutes > 0) {
         parts.push(`${minutes}분`);
     }
+
     if (seconds > 0 || parts.length === 0) {
         parts.push(`${seconds}초`);
     }
@@ -22,9 +24,53 @@ function formatSecondsToKoreanTime(totalSeconds) {
     return parts.join(" ");
 }
 
+function toNonNegativeNumber(value, fallback = 0) {
+    const numberValue = Number(value);
+
+    if (!Number.isFinite(numberValue)) {
+        return fallback;
+    }
+
+    return Math.max(0, Math.floor(numberValue));
+}
+
 function normalizeHomeResponse(raw) {
     const achievementCard = raw?.achievementCard ?? {};
+    const bookmarkCycleProgress = raw?.bookmarkCycleProgress ?? {};
     const rootFolders = Array.isArray(raw?.rootFolders) ? raw.rootFolders : [];
+
+    const totalBookmarkedProblemCount = toNonNegativeNumber(
+        bookmarkCycleProgress.totalBookmarkedProblemCount,
+        0
+    );
+
+    const rawCurrentCycleSolvedProblemCount = toNonNegativeNumber(
+        bookmarkCycleProgress.currentCycleSolvedProblemCount,
+        0
+    );
+
+    const currentCycleSolvedProblemCount =
+        totalBookmarkedProblemCount > 0
+            ? Math.min(rawCurrentCycleSolvedProblemCount, totalBookmarkedProblemCount)
+            : 0;
+
+    const currentBookmarkedRoundNo = Math.max(
+        1,
+        toNonNegativeNumber(bookmarkCycleProgress.currentBookmarkedRoundNo, 1)
+    );
+
+    const progressPercent =
+        bookmarkCycleProgress.progressPercent !== undefined &&
+        bookmarkCycleProgress.progressPercent !== null
+            ? Math.min(
+                100,
+                toNonNegativeNumber(bookmarkCycleProgress.progressPercent, 0)
+            )
+            : totalBookmarkedProblemCount > 0
+                ? Math.floor(
+                    (currentCycleSolvedProblemCount / totalBookmarkedProblemCount) * 100
+                )
+                : 0;
 
     return {
         summary: {
@@ -42,6 +88,15 @@ function normalizeHomeResponse(raw) {
                 goalCount: achievementCard.todayGoalCount ?? 10,
                 solvedCount: achievementCard.todayGoalSolvedCount ?? 0,
             },
+            bookmarkCycle: {
+                currentBookmarkedRoundNo,
+                totalBookmarkedProblemCount,
+                currentCycleSolvedProblemCount,
+                progressPercent,
+                isCompleted:
+                    totalBookmarkedProblemCount > 0 &&
+                    currentCycleSolvedProblemCount >= totalBookmarkedProblemCount,
+            },
         },
         rootFolders: rootFolders.map((folder) => ({
             folderId: folder.folderId,
@@ -51,7 +106,7 @@ function normalizeHomeResponse(raw) {
         })),
         quickActions: [
             { key: "RANDOM", label: "랜덤 문제 풀기" },
-            { key: "BOOKMARK", label: "북마크 문제 풀기" },
+            { key: "BOOKMARK", label: "북마크 문제 전체순회 시작" },
         ],
     };
 }

--- a/frontend/src/shared/api/quizApi.js
+++ b/frontend/src/shared/api/quizApi.js
@@ -1,6 +1,103 @@
 import { apiClient } from "./client.js";
 
-export async function getHealth() {
-    const response = await apiClient.get("/health");
-    return response.data;
+function toNonNegativeNumber(value, fallback = 0) {
+    const numberValue = Number(value);
+
+    if (!Number.isFinite(numberValue)) {
+        return fallback;
+    }
+
+    return Math.max(0, Math.floor(numberValue));
+}
+
+function normalizeExplanationToBlocks(explanation) {
+    if (!explanation || typeof explanation !== "string") {
+        return [];
+    }
+
+    return explanation
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((text) => ({
+            type: "TEXT",
+            text,
+        }));
+}
+
+function normalizeProblem(rawProblem, index) {
+    const problem = rawProblem ?? {};
+
+    const explanationText =
+        problem.explanationText ??
+        problem.explanation ??
+        "";
+
+    const explanationBlocks = Array.isArray(problem.explanationBlocks)
+        ? problem.explanationBlocks
+        : normalizeExplanationToBlocks(explanationText);
+
+    return {
+        ...problem,
+        problemId: problem.problemId ?? null,
+        questionNo:
+            problem.questionNo ??
+            problem.problemNum ??
+            index + 1,
+        questionText:
+            problem.questionText ??
+            problem.question ??
+            "",
+        answerText:
+            problem.answerText ??
+            problem.answer ??
+            "",
+        explanationText,
+        explanationBlocks,
+        questionImages: Array.isArray(problem.questionImages)
+            ? problem.questionImages
+            : [],
+        meta: {
+            ...(problem.meta ?? {}),
+            isBookmarked:
+                problem.meta?.isBookmarked ??
+                problem.isBookmarked ??
+                true,
+            attemptCount: toNonNegativeNumber(
+                problem.meta?.attemptCount ??
+                problem.solvedCount,
+                0
+            ),
+        },
+    };
+}
+
+function normalizePracticeResponse(raw, fallbackTitlePath) {
+    const problems = Array.isArray(raw?.problems) ? raw.problems : [];
+
+    return {
+        ...raw,
+        titlePath:
+            raw?.titlePath ??
+            raw?.folderPath ??
+            raw?.path ??
+            fallbackTitlePath,
+        problems: problems.map((problem, index) =>
+            normalizeProblem(problem, index)
+        ),
+    };
+}
+
+export async function getBookmarkedPractice(problemCount = 10) {
+    const response = await apiClient.post(
+        "/api/v1/problems/bookmarked/practice",
+        {
+            problemCount,
+        }
+    );
+
+    return normalizePracticeResponse(
+        response.data.result,
+        "북마크 문제 전체 순회"
+    );
 }


### PR DESCRIPTION
## 📝 작업 내용 설명

이번 PR에서는 북마크 문제 풀이 기능을 단순 빠른 실행 버튼이 아니라, 서비스의 핵심 반복 학습 흐름인 “북마크 문제 전체순회” 기능으로 분리했습니다.

기존 홈 화면에서는 레벨 정보가 일반 성취 카드에 표시되어 있었지만, 실제 레벨 상승 기준은 북마크된 문제 전체를 한 바퀴 순회 완료하는 것입니다.  
따라서 홈 화면에 북마크 전체순회 진행률 카드를 추가하고, 현재 북마크 라운드에서 전체 북마크 문제 중 몇 문제를 풀었는지 progress bar로 확인할 수 있도록 개선했습니다.

또한 북마크 전체순회 시작 버튼 클릭 시 `/quiz/play?mode=bookmark`로 진입하고, 해당 화면에서 `POST /api/v1/problems/bookmarked/practice` API를 호출하여 현재 라운드에서 이어서 풀 문제 목록을 조회하도록 연동했습니다.

폴더별 문제풀이와 북마크 전체순회 문제풀이가 서로 영향을 주지 않도록 `QuizPlayPage`에서 `folderId` 기반 풀이와 `mode=bookmark` 기반 풀이를 분리했습니다.


## ✅ 작업 내용

- [x] 홈 화면 빠른 실행 영역을 카테고리 영역 위로 이동
- [x] 홈 화면에 북마크 문제 전체순회 진행률 카드 추가
- [x] 레벨 정보를 북마크 전체순회 카드 영역으로 이동
- [x] 전체 북마크 문제 수 대비 현재 라운드 풀이 완료 수를 progress bar로 표시
- [x] 북마크 문제가 없는 경우 버튼 비활성화 및 안내 문구 표시
- [x] 홈 조회 API 응답에 북마크 순회 진행률 정보 추가
- [x] `LearningProgress.currentBookmarkedRoundNo` 기준으로 현재 라운드 풀이 완료 문제 수 계산
- [x] 북마크 전체순회 시작 버튼 클릭 시 `/quiz/play?mode=bookmark`로 이동
- [x] `mode=bookmark` 진입 시 북마크 전체순회 문제 조회 API 호출
- [x] 북마크 전체순회 API 요청 바디에 `problemCount` 전달
- [x] 폴더별 문제풀이와 북마크 전체순회 문제풀이 분기 처리
- [x] 개발 환경에서 POST API 중복 호출 가능성을 줄이기 위해 React StrictMode 제거


## 🔍 주요 변경 포인트

- `GET /api/v1/home` 응답에 `bookmarkCycleProgress`를 추가했습니다.
  - `currentBookmarkedRoundNo`
  - `totalBookmarkedProblemCount`
  - `currentCycleSolvedProblemCount`
  - `progressPercent`

- 홈 화면에서 북마크 전체순회 진행률을 다음 기준으로 표시하도록 변경했습니다.
  - 전체 북마크 문제 수: `isBookmarked = true`인 문제 수
  - 현재 라운드 풀이 완료 문제 수: `lastPracticedBookmarkedRoundNo >= currentBookmarkedRoundNo`인 북마크 문제 수

- `QuizPlayPage`에서 문제풀이 진입 방식을 분리했습니다.
  - `/quiz/play?folderId={folderId}`: 폴더별 문제풀이
  - `/quiz/play?mode=bookmark`: 북마크 전체순회 문제풀이

- 북마크 전체순회 문제 조회 API 호출 시 요청 바디를 함께 전달하도록 수정했습니다.

## 🧪 확인한 내용

 - [x] 로컬 환경에서 홈 화면 정상 렌더링 확인
 - [x] 홈 화면에서 북마크 전체순회 진행률 카드 표시 확인
 - [x] 홈 화면에서 Level 정보가 북마크 전체순회 영역에 표시되는지 확인
 - [x] API 요청/응답 확인
 - [x] 예외 케이스 전체 확인
 - [x] UI 상태 처리 전체 확인

## 📌 비고

현재 서비스는 단일 사용자 MVP 기준이므로 북마크 전체순회 진행률은 전역 LearningProgress와 Problem.lastPracticedBookmarkedRoundNo를 기준으로 계산합니다.
따라서 라운드 진행 중 새로 추가된 북마크 문제는 현재 라운드 완료 대상에 포함됩니다.

또한 POST /api/v1/problems/bookmarked/practice는 요청 바디로 problemCount를 필요로 하므로, 
프론트에서 기본값 10을 전달하도록 처리했습니다.

🔗 관련 이슈

closes #52 