### PR TITLE
feat(frontend/problem-submission): 문제 풀기 기능 연동

### DIFF
--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -57,7 +57,7 @@ export default function HomePage() {
 
     const { summary, rootFolders, quickActions } = homeData;
 
-    const randomAction = quickActions.find((action) => action.key === "RANDOM");
+    // const randomAction = quickActions.find((action) => action.key === "RANDOM");
     const bookmarkAction = quickActions.find((action) => action.key === "BOOKMARK");
 
     const bookmarkCycle = summary.bookmarkCycle;
@@ -97,19 +97,19 @@ export default function HomePage() {
             <div style={{ marginBottom: 32 }}>
                 <h2>빠른 실행</h2>
 
-                {randomAction && (
-                    <button
-                        type="button"
-                        onClick={() => navigate("/quiz/play?mode=random")}
-                        style={{
-                            marginBottom: 16,
-                            padding: "6px 12px",
-                            cursor: "pointer",
-                        }}
-                    >
-                        🎲 {randomAction.label}
-                    </button>
-                )}
+                {/*{randomAction && (*/}
+                {/*    <button*/}
+                {/*        type="button"*/}
+                {/*        onClick={() => navigate("/quiz/play?mode=random")}*/}
+                {/*        style={{*/}
+                {/*            marginBottom: 16,*/}
+                {/*            padding: "6px 12px",*/}
+                {/*            cursor: "pointer",*/}
+                {/*        }}*/}
+                {/*    >*/}
+                {/*        🎲 {randomAction.label}*/}
+                {/*    </button>*/}
+                {/*)}*/}
 
                 <div
                     style={{

--- a/frontend/src/pages/quiz/QuizPlayPage.jsx
+++ b/frontend/src/pages/quiz/QuizPlayPage.jsx
@@ -1,8 +1,25 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { getFolderPractice } from "../../shared/api/folderApi";
-import { getBookmarkedPractice } from "../../shared/api/quizApi";
+import {
+    getBookmarkedPractice,
+    submitProblemSubmission,
+} from "../../shared/api/quizApi";
 import FabGroup from "../../features/fab/FabGroup";
+
+const TEN_MINUTES_IN_SECONDS = 10 * 60;
+
+function getNowSeconds(startedAt) {
+    return Math.max(1, Math.floor((Date.now() - startedAt) / 1000));
+}
+
+function formatDuration(totalSeconds) {
+    const safeSeconds = Math.max(0, Math.floor(Number(totalSeconds) || 0));
+    const minutes = Math.floor(safeSeconds / 60);
+    const seconds = safeSeconds % 60;
+
+    return `${minutes}분 ${seconds}초`;
+}
 
 export default function QuizPlayPage() {
     const navigate = useNavigate();
@@ -29,6 +46,19 @@ export default function QuizPlayPage() {
     const [currentIndex, setCurrentIndex] = useState(0);
     const [showAnswer, setShowAnswer] = useState(false);
 
+    const [questionStartedAt, setQuestionStartedAt] = useState(Date.now());
+    const [submitting, setSubmitting] = useState(false);
+    const [submissionError, setSubmissionError] = useState("");
+    const [submittedProblemIds, setSubmittedProblemIds] = useState(() => new Set());
+
+    const [timeAdjustModal, setTimeAdjustModal] = useState({
+        open: false,
+        elapsedSeconds: 0,
+        minutes: "0",
+        seconds: "0",
+    });
+    const [timeAdjustError, setTimeAdjustError] = useState("");
+
     const problems = localProblems;
 
     useEffect(() => {
@@ -42,6 +72,9 @@ export default function QuizPlayPage() {
                 setShowCompleteScreen(false);
                 setCurrentIndex(0);
                 setShowAnswer(false);
+                setSubmissionError("");
+                setSubmittedProblemIds(new Set());
+                setQuestionStartedAt(Date.now());
 
                 if (isBookmarkMode) {
                     const data = await getBookmarkedPractice();
@@ -50,6 +83,7 @@ export default function QuizPlayPage() {
 
                     setLocalProblems(data.problems ?? []);
                     setTitlePath(data.titlePath ?? "북마크 문제 전체 순회");
+                    setQuestionStartedAt(Date.now());
                     return;
                 }
 
@@ -77,6 +111,7 @@ export default function QuizPlayPage() {
 
                 setLocalProblems(data.problems ?? []);
                 setTitlePath(data.titlePath || `폴더 ${folderId}`);
+                setQuestionStartedAt(Date.now());
             } catch (err) {
                 if (ignore) return;
 
@@ -96,6 +131,14 @@ export default function QuizPlayPage() {
             ignore = true;
         };
     }, [folderId, mode, isBookmarkMode, isRandomMode, isUnsupportedMode]);
+
+    useEffect(() => {
+        if (!loading && problems.length > 0 && !showCompleteScreen) {
+            setQuestionStartedAt(Date.now());
+            setSubmissionError("");
+            setTimeAdjustError("");
+        }
+    }, [currentIndex, loading, problems.length, showCompleteScreen]);
 
     const handleExit = () => {
         if (isBookmarkMode || isRandomMode || isUnsupportedMode) {
@@ -137,6 +180,186 @@ export default function QuizPlayPage() {
         }
 
         return "이 폴더의 문제를 끝까지 모두 확인했어요.";
+    };
+
+    const goNext = () => {
+        const next = currentIndex + 1;
+
+        if (next >= problems.length) {
+            setShowAnswer(false);
+            setShowCompleteScreen(true);
+            return;
+        }
+
+        setCurrentIndex(next);
+        setShowAnswer(false);
+    };
+
+    const goPrev = () => {
+        const prev = currentIndex - 1;
+
+        if (prev < 0) {
+            return;
+        }
+
+        setCurrentIndex(prev);
+        setShowAnswer(false);
+    };
+
+    const toggleBookmark = () => {
+        setLocalProblems((prev) =>
+            prev.map((p, idx) => {
+                if (idx !== currentIndex) return p;
+
+                return {
+                    ...p,
+                    meta: {
+                        ...p.meta,
+                        isBookmarked: !p.meta?.isBookmarked,
+                    },
+                };
+            })
+        );
+    };
+
+    const goEdit = () => {
+        const problem = problems[currentIndex];
+
+        if (!problem?.problemId) return;
+
+        navigate(`/quiz/${problem.problemId}/edit`);
+    };
+
+    const submitCurrentProblemAndGoNext = async (elapsedSeconds) => {
+        const problem = problems[currentIndex];
+
+        if (!problem?.problemId) {
+            setSubmissionError("문제 ID가 없어 제출 결과를 저장할 수 없습니다.");
+            return false;
+        }
+
+        if (submittedProblemIds.has(problem.problemId)) {
+            goNext();
+            return true;
+        }
+
+        try {
+            setSubmitting(true);
+            setSubmissionError("");
+
+            const result = await submitProblemSubmission({
+                problemId: problem.problemId,
+                isCorrect: true,
+                elapsedSeconds,
+            });
+
+            setSubmittedProblemIds((prev) => {
+                const next = new Set(prev);
+                next.add(problem.problemId);
+                return next;
+            });
+
+            setLocalProblems((prev) =>
+                prev.map((p, idx) => {
+                    if (idx !== currentIndex) return p;
+
+                    return {
+                        ...p,
+                        meta: {
+                            ...p.meta,
+                            attemptCount:
+                                result?.attemptCount ??
+                                (Number(p.meta?.attemptCount) || 0) + 1,
+                        },
+                    };
+                })
+            );
+
+            goNext();
+            return true;
+        } catch (err) {
+            console.error("문제 제출 결과 저장 실패:", err);
+            setSubmissionError("제출 결과를 저장하지 못했습니다. 다시 시도해주세요.");
+            return false;
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const openTimeAdjustModal = (elapsedSeconds) => {
+        const minutes = Math.floor(elapsedSeconds / 60);
+        const seconds = elapsedSeconds % 60;
+
+        setTimeAdjustModal({
+            open: true,
+            elapsedSeconds,
+            minutes: String(minutes),
+            seconds: String(seconds),
+        });
+        setTimeAdjustError("");
+    };
+
+    const closeTimeAdjustModal = () => {
+        if (submitting) return;
+
+        setTimeAdjustModal({
+            open: false,
+            elapsedSeconds: 0,
+            minutes: "0",
+            seconds: "0",
+        });
+        setTimeAdjustError("");
+    };
+
+    const handleNextClick = async () => {
+        if (submitting) return;
+
+        const problem = problems[currentIndex];
+
+        if (submittedProblemIds.has(problem?.problemId)) {
+            goNext();
+            return;
+        }
+
+        const elapsedSeconds = getNowSeconds(questionStartedAt);
+
+        if (elapsedSeconds >= TEN_MINUTES_IN_SECONDS) {
+            openTimeAdjustModal(elapsedSeconds);
+            return;
+        }
+
+        await submitCurrentProblemAndGoNext(elapsedSeconds);
+    };
+
+    const handleTimeAdjustSubmit = async () => {
+        const minutes = Number(timeAdjustModal.minutes);
+        const seconds = Number(timeAdjustModal.seconds);
+
+        if (!Number.isFinite(minutes) || !Number.isFinite(seconds)) {
+            setTimeAdjustError("분과 초를 숫자로 입력해주세요.");
+            return;
+        }
+
+        if (minutes < 0 || seconds < 0) {
+            setTimeAdjustError("분과 초는 0 이상으로 입력해주세요.");
+            return;
+        }
+
+        if (seconds >= 60) {
+            setTimeAdjustError("초는 0 이상 59 이하로 입력해주세요.");
+            return;
+        }
+
+        const elapsedSeconds = Math.max(
+            1,
+            Math.floor(minutes) * 60 + Math.floor(seconds)
+        );
+
+        const success = await submitCurrentProblemAndGoNext(elapsedSeconds);
+
+        if (success) {
+            closeTimeAdjustModal();
+        }
     };
 
     if (loading) {
@@ -200,51 +423,6 @@ export default function QuizPlayPage() {
 
     const problem = problems[currentIndex];
 
-    const goNext = () => {
-        const next = currentIndex + 1;
-
-        if (next >= problems.length) {
-            setShowAnswer(false);
-            setShowCompleteScreen(true);
-            return;
-        }
-
-        setCurrentIndex(next);
-        setShowAnswer(false);
-    };
-
-    const goPrev = () => {
-        const prev = currentIndex - 1;
-
-        if (prev < 0) {
-            return;
-        }
-
-        setCurrentIndex(prev);
-        setShowAnswer(false);
-    };
-
-    const toggleBookmark = () => {
-        setLocalProblems((prev) =>
-            prev.map((p, idx) => {
-                if (idx !== currentIndex) return p;
-
-                return {
-                    ...p,
-                    meta: {
-                        ...p.meta,
-                        isBookmarked: !p.meta?.isBookmarked,
-                    },
-                };
-            })
-        );
-    };
-
-    const goEdit = () => {
-        if (!problem?.problemId) return;
-        navigate(`/quiz/${problem.problemId}/edit`);
-    };
-
     return (
         <div style={{ maxWidth: 800, margin: "0 auto" }}>
             <div
@@ -284,16 +462,36 @@ export default function QuizPlayPage() {
                 </div>
             )}
 
-            <div style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" }}>
+            <div
+                style={{
+                    display: "flex",
+                    gap: 8,
+                    marginBottom: 16,
+                    flexWrap: "wrap",
+                }}
+            >
                 <button onClick={() => setShowAnswer((v) => !v)}>
                     {showAnswer ? "정답/해설 숨기기" : "정답/해설 보기"}
                 </button>
-                <button onClick={goPrev} disabled={currentIndex === 0}>
+
+                <button onClick={goPrev} disabled={currentIndex === 0 || submitting}>
                     이전 문제
                 </button>
-                <button onClick={goNext}>다음 문제</button>
-                <button onClick={handleExit}>{getExitButtonText()}</button>
+
+                <button onClick={handleNextClick} disabled={submitting}>
+                    {submitting ? "제출 중..." : "다음 문제"}
+                </button>
+
+                <button onClick={handleExit} disabled={submitting}>
+                    {getExitButtonText()}
+                </button>
             </div>
+
+            {submissionError && (
+                <p style={{ color: "crimson", marginTop: 0 }}>
+                    {submissionError}
+                </p>
+            )}
 
             {showAnswer && (
                 <div style={{ border: "1px solid #ddd", borderRadius: 12, padding: 16 }}>
@@ -305,6 +503,108 @@ export default function QuizPlayPage() {
                     <div>
                         <div style={{ opacity: 0.7, marginBottom: 6 }}>해설</div>
                         <ExplanationBlocks blocks={problem.explanationBlocks ?? []} />
+                    </div>
+                </div>
+            )}
+
+            {timeAdjustModal.open && (
+                <div
+                    style={{
+                        position: "fixed",
+                        inset: 0,
+                        backgroundColor: "rgba(0, 0, 0, 0.45)",
+                        display: "flex",
+                        justifyContent: "center",
+                        alignItems: "center",
+                        zIndex: 1000,
+                        padding: 16,
+                    }}
+                >
+                    <div
+                        style={{
+                            width: "100%",
+                            maxWidth: 420,
+                            backgroundColor: "#fff",
+                            borderRadius: 12,
+                            padding: 24,
+                            boxShadow: "0 8px 24px rgba(0, 0, 0, 0.2)",
+                        }}
+                    >
+                        <h2 style={{ marginTop: 0 }}>실제 풀이 시간 확인</h2>
+
+                        <p style={{ lineHeight: 1.6 }}>
+                            해당 문제를 푸는 데{" "}
+                            <strong>{formatDuration(timeAdjustModal.elapsedSeconds)}</strong>가
+                            소요되었습니다.
+                            <br />
+                            아래에 실제 경과시간을 적어주세요.
+                        </p>
+
+                        <div
+                            style={{
+                                display: "flex",
+                                gap: 8,
+                                alignItems: "center",
+                                marginBottom: 12,
+                            }}
+                        >
+                            <input
+                                type="number"
+                                min="0"
+                                value={timeAdjustModal.minutes}
+                                onChange={(e) =>
+                                    setTimeAdjustModal((prev) => ({
+                                        ...prev,
+                                        minutes: e.target.value,
+                                    }))
+                                }
+                                style={{
+                                    width: 80,
+                                    padding: 8,
+                                    fontSize: 16,
+                                }}
+                            />
+                            <span>분</span>
+
+                            <input
+                                type="number"
+                                min="0"
+                                max="59"
+                                value={timeAdjustModal.seconds}
+                                onChange={(e) =>
+                                    setTimeAdjustModal((prev) => ({
+                                        ...prev,
+                                        seconds: e.target.value,
+                                    }))
+                                }
+                                style={{
+                                    width: 80,
+                                    padding: 8,
+                                    fontSize: 16,
+                                }}
+                            />
+                            <span>초</span>
+                        </div>
+
+                        {timeAdjustError && (
+                            <p style={{ color: "crimson" }}>{timeAdjustError}</p>
+                        )}
+
+                        <div
+                            style={{
+                                display: "flex",
+                                justifyContent: "flex-end",
+                                gap: 8,
+                                marginTop: 20,
+                            }}
+                        >
+                            <button onClick={closeTimeAdjustModal} disabled={submitting}>
+                                취소
+                            </button>
+                            <button onClick={handleTimeAdjustSubmit} disabled={submitting}>
+                                {submitting ? "제출 중..." : "제출"}
+                            </button>
+                        </div>
                     </div>
                 </div>
             )}

--- a/frontend/src/shared/api/quizApi.js
+++ b/frontend/src/shared/api/quizApi.js
@@ -64,8 +64,7 @@ function normalizeProblem(rawProblem, index) {
                 problem.isBookmarked ??
                 true,
             attemptCount: toNonNegativeNumber(
-                problem.meta?.attemptCount ??
-                problem.solvedCount,
+                problem.meta?.attemptCount ?? problem.solvedCount,
                 0
             ),
         },
@@ -100,4 +99,18 @@ export async function getBookmarkedPractice(problemCount = 10) {
         response.data.result,
         "북마크 문제 전체 순회"
     );
+}
+
+export async function submitProblemSubmission({
+                                                  problemId,
+                                                  isCorrect,
+                                                  elapsedSeconds,
+                                              }) {
+    const response = await apiClient.post("/problem-submissions", {
+        problemId,
+        isCorrect,
+        elapsedSeconds,
+    });
+
+    return response.data.result;
 }


### PR DESCRIPTION
## 📝 작업 내용 설명

이번 PR에서는 문제 풀이 화면에서 사용자가 `다음 문제` 버튼을 클릭했을 때, 현재 문제를 푼 것으로 판단하여 백엔드의 문제 제출 결과 저장 API와 연동했습니다.

기존에는 문제를 화면에서 넘기는 동작만 가능했지만, 실제 풀이 기록이 서버에 저장되지는 않았습니다.  
이번 작업을 통해 문제별 풀이 횟수, 오늘 푼 문제 수, 오늘 자투리 시간, 누적 자투리 시간 등의 통계가 문제 풀이 흐름과 연결되도록 했습니다.

또한 문제별 풀이 시간을 측정하여 `elapsedSeconds` 값으로 제출하고, 한 문제에서 10분 이상 머문 경우에는 실제 풀이 시간을 사용자가 보정해서 제출할 수 있도록 처리했습니다.

랜덤 문제 풀기 기능은 아직 조회 API 및 전체 흐름이 완성되지 않았으므로, 홈 화면의 랜덤 문제 풀기 버튼은 임시로 비활성화했습니다.

## ✅ 작업 내용

- [x] 문제 제출 결과 저장 API 연동 함수 추가
- [x] 문제 풀이 화면에서 `다음 문제` 클릭 시 제출 API 호출
- [x] 문제별 풀이 시작 시각 기준으로 `elapsedSeconds` 계산
- [x] 제출 성공 후 다음 문제로 이동하도록 흐름 수정
- [x] 문제 제출 중 버튼 중복 클릭 방지 처리
- [x] 제출 실패 시 오류 메시지 표시
- [x] 한 문제 풀이 시간이 10분 이상인 경우 실제 풀이 시간 보정 모달 표시
- [x] 보정된 분/초 값을 `elapsedSeconds`로 변환하여 제출
- [x] 홈 화면의 랜덤 문제 풀기 버튼 임시 비활성화

## 🔍 주요 변경 포인트

- `quizApi.js`에 `submitProblemSubmission()` 함수를 추가하여 `POST /problem-submissions` API와 연동했습니다.
- `QuizPlayPage.jsx`에서 `다음 문제` 버튼 클릭 시 현재 문제의 풀이 결과를 서버에 저장한 뒤 다음 문제로 넘어가도록 변경했습니다.
- 문제 화면 진입 또는 다음 문제 이동 시점마다 풀이 시작 시각을 새로 기록하여 문제별 경과 시간을 계산하도록 했습니다.
- 10분 이상 경과한 경우 자동 제출하지 않고, 실제 풀이 시간을 사용자가 직접 확인/수정한 뒤 제출할 수 있도록 모달을 추가했습니다.
- 아직 랜덤 문제 풀기 기능은 완성되지 않았으므로 홈 화면의 랜덤 문제 풀기 버튼을 주석 처리하여 사용자 진입을 막았습니다.

## 🧪 확인한 내용

- [x] 로컬 환경에서 정상 동작 확인
- [x] API 요청/응답 확인
- [x] 다음 문제 클릭 시 `POST /problem-submissions` 요청이 전송되는지 확인
- [x] `elapsedSeconds` 값이 문제별 경과 시간 기준으로 전송되는지 확인
- [x] 제출 성공 후 다음 문제로 이동하는지 확인
- [x] 10분 이상 경과 시 풀이 시간 보정 모달이 표시되는지 확인
- [x] 보정 모달에서 분/초 입력 후 제출 시 초 단위로 변환되어 요청되는지 확인
- [x] 홈 화면에서 랜덤 문제 풀기 버튼이 표시되지 않는지 확인
- [x] UI 상태 처리 확인

## 📌 비고

- 현재 정답/오답을 별도로 구분하는 버튼은 두지 않았습니다.
- 본 서비스에서는 `다음 문제` 버튼 클릭을 해당 문제 풀이 완료로 간주합니다.
- 틀렸거나 다시 보고 싶은 문제는 북마크로 관리하는 흐름을 유지합니다.
- 랜덤 문제 풀기 기능은 아직 조회 API 및 문제 목록 구성 흐름이 완성되지 않아 버튼만 임시 비활성화했습니다.
- 북마크 토글 저장 API 연동은 별도 이슈에서 진행할 수 있습니다.

## 🔗 관련 이슈

closes #54