### PR TITLE
fix(backend/config): 운영 API 도메인 CORS 허용 추가

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/WebConfig.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/WebConfig.java
@@ -15,7 +15,8 @@ public class WebConfig implements WebMvcConfigurer {
                         "http://localhost:5173",
                         "https://jatuli.online",
                         "https://www.jatuli.online",
-                        "https://jatuli-quiz-frontend.vercel.app"
+                        "https://jatuli-quiz-frontend.vercel.app",
+                        "https://api.jatuli.online"
                 )
                 .allowedMethods("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")


### PR DESCRIPTION
## 📝 작업 내용 설명

운영 환경 Swagger UI에서 문제 문자열 일괄 등록 API를 호출할 때 `403 Invalid CORS request`가 발생하는 문제가 있었다.

Swagger UI를 `https://api.jatuli.online` 도메인에서 접근하는 경우 해당 Origin이 CORS 허용 목록에 포함되어 있지 않아 요청이 차단된 것으로 판단하여, 운영 API 도메인을 CORS 허용 Origin에 추가했다.


## ✅ 작업 내용

- [x] CORS 허용 Origin에 `https://api.jatuli.online` 추가
- [x] 기존 로컬 및 운영 프론트엔드 허용 Origin 유지


## 🔍 주요 변경 포인트

- `WebConfig`의 `allowedOrigins` 목록에 운영 API 도메인 추가
- Swagger UI에서 발생하는 CORS 차단 가능성 해소
- 기존 프론트엔드 도메인 및 로컬 개발 환경 CORS 설정은 변경하지 않음


## 🧪 확인한 내용

- [ ] API 요청/응답 확인
- [ ] 기존 기능 회귀 확인


## 📌 비고

배포 후 `https://api.jatuli.online/swagger-ui/index.html`에서 문제 문자열 일괄 등록 API를 다시 호출하여 `403 Invalid CORS request`가 해결되었는지 확인해야 한다.

## 🔗 관련 이슈

closes #56