### PR TITLE
fix(frontend/mobile): iPhone Safari 좌우 여백 개선

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -36,18 +36,40 @@
     --color-button-disabled-text: #6b7280;
 }
 
-* {
+*,
+*::before,
+*::after {
     box-sizing: border-box;
 }
 
-html,
-body,
-#root {
+html {
+    width: 100%;
     min-height: 100%;
     margin: 0;
+    background: var(--color-bg);
+
+    /* iPhone Safari에서 임의 글자 확대 방지 */
+    -webkit-text-size-adjust: 100%;
 }
 
 body {
+    width: 100%;
+    min-height: 100%;
+    margin: 0;
     background: var(--color-bg);
     color: var(--color-text);
+    overflow-x: hidden;
+
+    /* Vite 기본 CSS나 브라우저 기본 레이아웃 영향 방지 */
+    display: block;
+    place-items: initial;
+}
+
+#root {
+    width: 100%;
+    max-width: none;
+    min-height: 100vh;
+    margin: 0;
+    padding: 0;
+    text-align: initial;
 }

--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -5,10 +5,12 @@ import { createFolder } from "../../shared/api/folderApi";
 import { importProblemsText } from "../../shared/api/quizApi";
 
 const pageStyle = {
+    width: "100%",
     maxWidth: 880,
     margin: "0 auto",
-    padding: "32px 20px 56px",
+    padding: "32px clamp(8px, 3vw, 20px) 56px",
     color: "var(--color-text)",
+    boxSizing: "border-box",
 };
 
 const sectionStyle = {
@@ -16,19 +18,23 @@ const sectionStyle = {
 };
 
 const cardStyle = {
+    width: "100%",
+    boxSizing: "border-box",
     border: "1px solid var(--color-border)",
     background: "var(--color-surface)",
     color: "var(--color-text)",
     borderRadius: 18,
-    padding: 20,
+    padding: "clamp(16px, 4vw, 20px)",
 };
 
 const softCardStyle = {
+    width: "100%",
+    boxSizing: "border-box",
     border: "1px solid var(--color-border)",
     background: "var(--color-surface)",
     color: "var(--color-text)",
     borderRadius: 16,
-    padding: 18,
+    padding: "clamp(14px, 3.5vw, 18px)",
 };
 
 const mutedTextStyle = {
@@ -431,7 +437,7 @@ function FolderTreeItem({
                             alignItems: "center",
                             gap: 8,
                             minWidth: 0,
-                            paddingLeft: depth * 16,
+                            paddingLeft: depth * 3,
                         }}
                     >
                     <span
@@ -590,7 +596,7 @@ function FolderTreeItem({
             {creatingParentFolder?.folderId === folder.folderId && (
                 <div
                     style={{
-                        marginLeft: depth * 16 + 34,
+                        marginLeft: depth * 12 + 30,
                         marginTop: 4,
                         marginBottom: 8,
                         display: "flex",
@@ -637,8 +643,8 @@ function FolderTreeItem({
             {hasChildren && !isCollapsed && (
                 <div
                     style={{
-                        marginLeft: depth * 16 + 11,
-                        paddingLeft: 12,
+                        marginLeft: depth * 12 + 8,
+                        paddingLeft: 10,
                         borderLeft: "1px solid var(--color-border)",
                     }}
                 >
@@ -1278,7 +1284,7 @@ export default function HomePage() {
                     <div
                         style={{
                             ...cardStyle,
-                            padding: "10px 16px",
+                            padding: "10px clamp(8px, 3vw, 16px)",
                         }}
                     >
                         {rootFolders.map((folder, index) => (

--- a/frontend/src/pages/quiz/QuizPlayPage.jsx
+++ b/frontend/src/pages/quiz/QuizPlayPage.jsx
@@ -11,9 +11,12 @@ import MarkdownContent from "../../shared/components/MarkdownContent";
 const TEN_MINUTES_IN_SECONDS = 10 * 60;
 
 const pageStyle = {
+    width: "100%",
     maxWidth: 800,
     margin: "0 auto",
+    padding: "24px clamp(8px, 3vw, 20px) 72px",
     color: "var(--color-text, #f9fafb)",
+    boxSizing: "border-box",
 };
 
 const mutedTextStyle = {
@@ -27,11 +30,13 @@ const hrStyle = {
 };
 
 const answerCardStyle = {
+    width: "100%",
+    boxSizing: "border-box",
     border: "1px solid var(--color-border, #374151)",
     background: "var(--color-surface, #1f2937)",
     color: "var(--color-text, #f9fafb)",
     borderRadius: 12,
-    padding: 16,
+    padding: "clamp(14px, 3.5vw, 16px)",
     marginBottom: 16,
 };
 


### PR DESCRIPTION
## 📝 작업 내용 설명

현재 iPhone Safari 환경에서 홈 화면과 문제 풀이 화면의 콘텐츠가 화면 너비를 충분히 사용하지 못하고, 좌우 여백이 과도하게 넓게 표시되는 문제가 있었다.

이번 작업에서는 모바일 Safari 환경에서도 페이지 컨테이너와 주요 카드 영역이 화면 너비를 자연스럽게 사용할 수 있도록 전역 CSS와 주요 페이지 레이아웃 스타일을 정리한다.

특히 `index.css`의 전역 레이아웃 초기화 설정을 보강하고, `HomePage`, `QuizPlayPage`의 페이지 컨테이너 및 카드 스타일에 `width`, `boxSizing`, 반응형 `padding`을 적용하여 모바일 화면에서 지나치게 좁아 보이는 문제를 개선한다.

## ✅ 작업 내용

* [x] `index.css`의 `html`, `body`, `#root` 전역 레이아웃 초기화 설정 보강
* [x] `#root`의 `max-width`, `padding`, `text-align` 영향을 제거하도록 명시
* [x] iPhone Safari 대응을 위해 `-webkit-text-size-adjust` 설정 추가
* [x] `HomePage`의 최상위 `pageStyle`에 `width: 100%`, `boxSizing: border-box`, 반응형 padding 적용
* [x] `HomePage`의 카드 스타일에 `width: 100%`, `boxSizing: border-box` 적용
* [x] `QuizPlayPage`의 최상위 `pageStyle`에 `width: 100%`, `boxSizing: border-box`, 반응형 padding 적용
* [x] 문제 풀이 화면의 답변 카드 스타일에 모바일 대응용 너비 설정 보강

## 🔍 주요 변경 포인트

* 모바일 화면에서 페이지 컨테이너가 부모 요소의 너비를 온전히 사용할 수 있도록 `width: 100%`를 명시
* padding이 모바일에서 과도하게 적용되지 않도록 `clamp()` 기반 반응형 여백 적용
* 카드와 페이지 컨테이너에 `boxSizing: border-box`를 적용하여 padding 포함 계산이 안정적으로 이루어지도록 수정
* 전역 CSS에서 Vite 기본 스타일이나 브라우저 기본 레이아웃의 영향을 받을 수 있는 부분을 방어적으로 초기화
* 기능 로직/API 연동 변경 없이 모바일 레이아웃 표시 문제만 개선

## 🧪 확인한 내용

* [ ] 로컬 환경에서 정상 동작 확인
* [ ] iPhone Safari에서 홈 화면 좌우 여백 개선 확인
* [ ] iPhone Safari에서 문제 풀이 화면 좌우 여백 개선 확인
* [ ] 기존 기능 회귀 확인
* [ ] 가로 스크롤 발생 여부 확인
* [ ] PC 화면에서 기존 레이아웃이 깨지지 않는지 확인

## 📌 비고

이번 작업은 기능 변경이 아니라 모바일 사용성 개선을 위한 스타일 수정이다.

현재 문제는 실제 iPhone Safari 환경에서 확인된 레이아웃 이슈이므로, 머지 후 배포 환경에서 최종 화면을 다시 확인할 예정이다.

만약 배포 후에도 일부 화면에서 여백이 과도하게 남는 경우, 해당 화면의 개별 컨테이너 또는 컴포넌트 스타일을 후속 PR에서 추가로 조정한다.

## 🔗 관련 이슈

<!-- closes #이슈번호 -->
