### PR TITLE
fix(frontend/mobile): AppShell 전역 padding 제거

### DIFF
--- a/frontend/src/app/AppShell.jsx
+++ b/frontend/src/app/AppShell.jsx
@@ -4,10 +4,14 @@ export default function AppShell() {
     return (
         <div
             style={{
+                width: "100%",
                 minHeight: "100vh",
-                padding: 50,
+                margin: 0,
+                padding: 0,
                 background: "var(--color-bg)",
                 color: "var(--color-text)",
+                boxSizing: "border-box",
+                overflowX: "hidden",
             }}
         >
             <Outlet />


### PR DESCRIPTION
## 📝 작업 내용 설명

iPhone Safari 환경에서 화면 좌우 여백이 과도하게 발생하는 문제가 있었다.

원인을 확인한 결과, 모든 페이지를 감싸는 `AppShell`에 `padding: 50`이 적용되어 모바일 화면에서도 좌우 50px 여백이 강제로 생기고 있었다.

이번 작업에서는 `AppShell`의 전역 padding을 제거하여 각 페이지가 자체 레이아웃 기준으로 모바일 화면 너비를 사용할 수 있도록 수정한다.

## ✅ 작업 내용

* [x] `AppShell.jsx`의 전역 `padding: 50` 제거
* [x] `AppShell`에 `width: 100%`, `boxSizing: border-box` 적용
* [x] 전체 앱 레이아웃에서 불필요한 좌우 여백 제거

## 🔍 주요 변경 포인트

* 모든 페이지에 공통 적용되던 AppShell padding 제거
* 모바일 Safari에서 콘텐츠 영역이 좁게 표시되던 원인 수정
* 개별 페이지의 반응형 padding은 유지하고, 공통 레이아웃에서는 여백을 강제하지 않도록 변경

## 🧪 확인한 내용

* [ ] 로컬 환경에서 정상 동작 확인
* [ ] iPhone Safari에서 좌우 여백 개선 확인
* [ ] 홈 화면 레이아웃 확인
* [ ] 문제 풀이 화면 레이아웃 확인
* [ ] PC 화면에서 기존 레이아웃이 깨지지 않는지 확인

## 📌 비고

이전 PR에서 페이지별 반응형 스타일을 수정했지만, 실제 원인은 공통 레이아웃인 `AppShell`의 전역 padding이었다.

이번 PR은 해당 공통 padding을 제거하는 후속 수정 작업이다.

## 🔗 관련 이슈

<!-- closes #63 -->
