### PR TITLE
feat(frontend/bookmark): 북마크 토글 api 연동 완료

### DIFF
--- a/frontend/src/pages/quiz/QuizPlayPage.jsx
+++ b/frontend/src/pages/quiz/QuizPlayPage.jsx
@@ -8,6 +8,7 @@ import { getFolderPractice } from "../../shared/api/folderApi";
 import {
     getBookmarkedPractice,
     submitProblemSubmission,
+    toggleProblemBookmark,
 } from "../../shared/api/quizApi";
 import FabGroup from "../../features/fab/FabGroup";
 import MarkdownContent from "../../shared/components/MarkdownContent";
@@ -451,6 +452,9 @@ export default function QuizPlayPage() {
     const [submissionError, setSubmissionError] = useState("");
     const [submittedProblemIds, setSubmittedProblemIds] = useState(() => new Set());
 
+    const [bookmarkSubmitting, setBookmarkSubmitting] = useState(false);
+    const [bookmarkError, setBookmarkError] = useState("");
+
     const [timeAdjustModal, setTimeAdjustModal] = useState({
         open: false,
         elapsedSeconds: 0,
@@ -473,6 +477,7 @@ export default function QuizPlayPage() {
                 setCurrentIndex(0);
                 setShowAnswer(false);
                 setSubmissionError("");
+                setBookmarkError("");
                 setSubmittedProblemIds(new Set());
                 setQuestionStartedAt(Date.now());
 
@@ -597,6 +602,7 @@ export default function QuizPlayPage() {
         if (!loading && problems.length > 0 && !showCompleteScreen) {
             setQuestionStartedAt(Date.now());
             setSubmissionError("");
+            setBookmarkError("");
             setTimeAdjustError("");
 
             if ("speechSynthesis" in window) {
@@ -706,20 +712,60 @@ export default function QuizPlayPage() {
         setShowAnswer(false);
     };
 
-    const toggleBookmark = () => {
+    const updateProblemBookmarkState = (targetProblemId, isBookmarked) => {
         setLocalProblems((prev) =>
-            prev.map((p, idx) => {
-                if (idx !== currentIndex) return p;
+            prev.map((p) => {
+                if (String(p.problemId) !== String(targetProblemId)) {
+                    return p;
+                }
 
                 return {
                     ...p,
                     meta: {
                         ...p.meta,
-                        isBookmarked: !p.meta?.isBookmarked,
+                        isBookmarked,
                     },
                 };
             })
         );
+    };
+
+    const handleToggleBookmark = async () => {
+        if (bookmarkSubmitting || nextSplashOpen) return;
+
+        const problem = problems[currentIndex];
+
+        if (!problem?.problemId) {
+            setBookmarkError("문제 ID가 없어 북마크 상태를 변경할 수 없습니다.");
+            return;
+        }
+
+        const problemId = problem.problemId;
+        const previousBookmarked = !!problem.meta?.isBookmarked;
+        const optimisticBookmarked = !previousBookmarked;
+
+        try {
+            setBookmarkSubmitting(true);
+            setBookmarkError("");
+
+            // 클릭 즉시 아이콘 상태를 먼저 바꿔서 반응성을 좋게 만든다.
+            updateProblemBookmarkState(problemId, optimisticBookmarked);
+
+            // 서버에 실제 북마크 토글 요청
+            const result = await toggleProblemBookmark(problemId);
+
+            // 서버가 내려준 최신 상태로 다시 동기화
+            updateProblemBookmarkState(problemId, result.isBookmarked);
+        } catch (err) {
+            console.error("북마크 토글 실패:", err);
+
+            // 실패하면 원래 상태로 되돌린다.
+            updateProblemBookmarkState(problemId, previousBookmarked);
+
+            setBookmarkError("북마크 상태를 변경하지 못했습니다. 다시 시도해주세요.");
+        } finally {
+            setBookmarkSubmitting(false);
+        }
     };
 
     const goEdit = () => {
@@ -1112,6 +1158,17 @@ export default function QuizPlayPage() {
                     {submissionError}
                 </p>
             )}
+
+            {bookmarkError && (
+                <p
+                    style={{
+                        color: "var(--color-danger, #fca5a5)",
+                        marginTop: 0,
+                    }}
+                >
+                    {bookmarkError}
+                </p>
+            )}
             <div
                 onClick={(e) => e.stopPropagation()}
                 style={bottomLeftControlsStyle}
@@ -1146,7 +1203,8 @@ export default function QuizPlayPage() {
             >
                 <BookmarkToggleButton
                     isBookmarked={!!problem?.meta?.isBookmarked}
-                    onClick={toggleBookmark}
+                    onClick={handleToggleBookmark}
+                    disabled={bookmarkSubmitting || nextSplashOpen}
                 />
             </div>
 
@@ -1280,14 +1338,18 @@ export default function QuizPlayPage() {
     );
 }
 
-function BookmarkToggleButton({ isBookmarked, onClick }) {
+function BookmarkToggleButton({ isBookmarked, onClick, disabled = false }) {
     return (
         <button
             type="button"
             onClick={(e) => {
                 e.stopPropagation();
+
+                if (disabled) return;
+
                 onClick();
             }}
+            disabled={disabled}
             aria-label={isBookmarked ? "북마크 해제" : "북마크 추가"}
             title={isBookmarked ? "북마크 해제" : "북마크 추가"}
             style={{
@@ -1301,7 +1363,8 @@ function BookmarkToggleButton({ isBookmarked, onClick }) {
                 color: isBookmarked
                     ? "var(--color-primary, #f59e0b)"
                     : "var(--color-text-muted, #9ca3af)",
-                cursor: "pointer",
+                cursor: disabled ? "not-allowed" : "pointer",
+                opacity: disabled ? 0.6 : 1,
                 padding: 0,
                 flexShrink: 0,
             }}

--- a/frontend/src/shared/api/quizApi.js
+++ b/frontend/src/shared/api/quizApi.js
@@ -59,3 +59,20 @@ export async function importProblemsText({ folderId, rawText }) {
             : [],
     };
 }
+
+export async function toggleProblemBookmark(problemId) {
+    if (!problemId) {
+        throw new Error("problemId is required");
+    }
+
+    const response = await apiClient.post(
+        `/api/v1/problems/${problemId}/bookmark`
+    );
+
+    const result = response.data.result ?? {};
+
+    return {
+        problemId: result.problemId ?? problemId,
+        isBookmarked: !!result.isBookmarked,
+    };
+}


### PR DESCRIPTION
## 📝 작업 내용 설명

문제 풀이 화면의 북마크 토글 버튼을 백엔드 북마크 토글 API와 연동했습니다.

기존에는 북마크 버튼 클릭 시 프론트엔드 상태만 변경되어 새로고침하거나 다시 문제를 불러오면 변경 내용이 유지되지 않았습니다.
이번 작업에서는 문제별 북마크 상태를 서버에 저장하고, API 응답으로 받은 최신 북마크 상태를 화면에 반영하도록 수정했습니다.

## ✅ 작업 내용

* [x] 북마크 토글 API 함수 추가
* [x] 문제 풀이 화면의 북마크 버튼 클릭 시 API 요청 연동
* [x] API 응답의 `isBookmarked` 값으로 화면 상태 동기화
* [x] 요청 실패 시 기존 북마크 상태로 롤백 처리
* [x] 북마크 토글 중 중복 클릭 방지 처리

## 🔍 주요 변경 포인트

* `POST /api/v1/problems/{problemId}/bookmark` API 연동
* 기존 프론트 로컬 상태 변경 방식에서 서버 동기화 방식으로 변경
* 북마크 토글 실패 시 사용자에게 에러 메시지 표시
* 북마크 버튼 비활성화 상태 추가

## 🧪 확인한 내용

* [x] 로컬 환경에서 북마크 토글 버튼 클릭 동작 확인
* [x] API 요청/응답 확인
* [x] 북마크 추가/해제 시 아이콘 상태 변경 확인
* [x] API 실패 시 기존 상태로 롤백되는지 확인
* [x] 문제 풀이 화면 기존 기능 회귀 확인

## 📌 비고

북마크 문제 전체 순회 중 북마크를 해제하더라도 현재 불러온 문제 목록에서는 즉시 제거하지 않고, 아이콘 상태만 변경되도록 처리했습니다.
다음에 북마크 문제를 다시 불러올 때 서버의 최신 북마크 상태가 반영됩니다.

## 🔗 관련 이슈

closes #59
