### PR TITLE
feat(folder): 폴더 관리 API 구현 및 프론트 연동

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/common/exception/code/status/ErrorStatus.java
@@ -19,7 +19,12 @@ public enum ErrorStatus implements BaseErrorCode {
     // 폴더 관련 에러
     FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER4041", "존재하지 않는 폴더입니다."),
     FOLDER_NOT_LEAF(HttpStatus.BAD_REQUEST, "FOLDER4001", "연습 문제 조회는 leaf 폴더에서만 가능합니다."),
-    DUPLICATE_FOLDER_NAME(HttpStatus.BAD_REQUEST, "FOLDER4001", "같은 부모 폴더 아래에 동일한 이름의 폴더가 이미 존재합니다."),
+    DUPLICATE_FOLDER_NAME(HttpStatus.BAD_REQUEST, "FOLDER4002", "같은 부모 폴더 아래에 동일한 이름의 폴더가 이미 존재합니다."),
+    ROOT_FOLDER_CANNOT_BE_MODIFIED(HttpStatus.BAD_REQUEST, "FOLDER4003", "루트 폴더는 수정하거나 삭제할 수 없습니다."),
+    FOLDER_HAS_CHILDREN(HttpStatus.BAD_REQUEST, "FOLDER4004", "하위 폴더가 존재하는 폴더는 삭제할 수 없습니다."),
+    FOLDER_HAS_PROBLEMS(HttpStatus.BAD_REQUEST, "FOLDER4005", "문제가 존재하는 폴더는 삭제할 수 없습니다."),
+    INVALID_FOLDER_ORDER(HttpStatus.BAD_REQUEST, "FOLDER4006", "올바르지 않은 폴더 순서 요청입니다."),
+
 
     // 문제 관련 에러
     PROBLEM_NOT_FOUND(HttpStatus.NOT_FOUND, "PROBLEM4041", "존재하지 않는 문제입니다."),

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/FolderRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/FolderRestController.java
@@ -10,7 +10,9 @@ import com.hhd1337.jatuli_quiz.domain.folder.service.FolderQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -69,5 +71,59 @@ public class FolderRestController {
             @Valid @RequestBody FolderRequest.CreateFolderRequest request
     ) {
         return ApiResponse.onSuccess(folderCommandService.createFolder(request));
+    }
+
+    @Operation(
+            summary = "폴더 이름 변경",
+            description = """
+                    특정 폴더의 이름을 변경합니다.
+                    루트 폴더는 이름을 변경할 수 없습니다.
+                    같은 부모 폴더 아래에 동일한 이름의 폴더가 이미 존재하면 변경을 차단합니다.
+                    폴더 이름 변경 시 해당 폴더와 하위 폴더들의 fullPath도 함께 갱신됩니다.
+                    """
+    )
+    @PatchMapping("/{folderId}/name")
+    public ApiResponse<FolderResponse.RenameFolderResponse> renameFolder(
+            @PathVariable Long folderId,
+            @Valid @RequestBody FolderRequest.RenameFolderRequest request
+    ) {
+        return ApiResponse.onSuccess(
+                folderCommandService.renameFolder(folderId, request)
+        );
+    }
+
+    @Operation(
+            summary = "폴더 삭제",
+            description = """
+                    특정 폴더를 삭제합니다.
+                    루트 폴더는 삭제할 수 없습니다.
+                    현재 정책에서는 하위 폴더나 문제가 존재하는 폴더는 삭제할 수 없습니다.
+                    """
+    )
+    @DeleteMapping("/{folderId}")
+    public ApiResponse<FolderResponse.DeleteFolderResponse> deleteFolder(
+            @PathVariable Long folderId
+    ) {
+        return ApiResponse.onSuccess(
+                folderCommandService.deleteFolder(folderId)
+        );
+    }
+
+    @Operation(
+            summary = "하위 폴더 순서 변경",
+            description = """
+                    특정 부모 폴더 아래의 직계 하위 폴더 순서를 변경합니다.
+                    orderedFolderIds에는 해당 부모 폴더의 직계 자식 폴더 ID 전체를 원하는 순서대로 전달해야 합니다.
+                    다른 부모에 속한 폴더 ID가 포함되거나, 누락/중복된 ID가 있으면 요청을 차단합니다.
+                    """
+    )
+    @PatchMapping("/{parentFolderId}/children/order")
+    public ApiResponse<FolderResponse.ReorderFoldersResponse> reorderChildFolders(
+            @PathVariable Long parentFolderId,
+            @Valid @RequestBody FolderRequest.ReorderFoldersRequest request
+    ) {
+        return ApiResponse.onSuccess(
+                folderCommandService.reorderChildFolders(parentFolderId, request)
+        );
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/converter/FolderConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/converter/FolderConverter.java
@@ -43,6 +43,7 @@ public class FolderConverter {
                 .solved(solved)
                 .total(total)
                 .hasChildren(hasChildren)
+                .sortOrder(folder.getSortOrder())
                 .build();
     }
 
@@ -82,6 +83,41 @@ public class FolderConverter {
                 .fullPath(folder.getFullPath())
                 .depth(folder.getDepth())
                 .problemCount(folder.getProblemCount())
+                .build();
+    }
+
+    public static FolderResponse.RenameFolderResponse toRenameFolderResponse(Folder folder) {
+        return FolderResponse.RenameFolderResponse.builder()
+                .folderId(folder.getFolderId())
+                .parentFolderId(folder.getParentFolder().getFolderId())
+                .name(folder.getName())
+                .fullPath(folder.getFullPath())
+                .depth(folder.getDepth())
+                .build();
+    }
+
+    public static FolderResponse.DeleteFolderResponse toDeleteFolderResponse(Long folderId) {
+        return FolderResponse.DeleteFolderResponse.builder()
+                .folderId(folderId)
+                .build();
+    }
+
+    public static FolderResponse.ReorderFoldersResponse toReorderFoldersResponse(
+            Long parentFolderId,
+            List<Folder> folders
+    ) {
+        List<FolderResponse.ReorderFoldersResponse.ReorderedFolderDTO> folderDtos =
+                folders.stream()
+                        .map(folder -> FolderResponse.ReorderFoldersResponse.ReorderedFolderDTO.builder()
+                                .folderId(folder.getFolderId())
+                                .name(folder.getName())
+                                .sortOrder(folder.getSortOrder())
+                                .build())
+                        .toList();
+
+        return FolderResponse.ReorderFoldersResponse.builder()
+                .parentFolderId(parentFolderId)
+                .folders(folderDtos)
                 .build();
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/dto/FolderRequest.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/dto/FolderRequest.java
@@ -1,8 +1,10 @@
 package com.hhd1337.jatuli_quiz.domain.folder.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,5 +22,22 @@ public class FolderRequest {
         @NotBlank(message = "폴더 이름은 필수입니다.")
         @Size(max = 100, message = "폴더 이름은 100자를 초과할 수 없습니다.")
         private String name;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class RenameFolderRequest {
+
+        @NotBlank(message = "폴더 이름은 필수입니다.")
+        @Size(max = 100, message = "폴더 이름은 100자를 초과할 수 없습니다.")
+        private String name;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ReorderFoldersRequest {
+
+        @NotEmpty(message = "폴더 순서 목록은 비어 있을 수 없습니다.")
+        private List<@NotNull Long> orderedFolderIds;
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/dto/FolderResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/dto/FolderResponse.java
@@ -35,6 +35,7 @@ public class FolderResponse {
             private Integer solved;
             private Integer total;
             private Boolean hasChildren;
+            private Integer sortOrder;
         }
     }
 
@@ -77,5 +78,44 @@ public class FolderResponse {
         private String fullPath;
         private Integer depth;
         private Integer problemCount;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RenameFolderResponse {
+        private Long folderId;
+        private Long parentFolderId;
+        private String name;
+        private String fullPath;
+        private Integer depth;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeleteFolderResponse {
+        private Long folderId;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReorderFoldersResponse {
+        private Long parentFolderId;
+        private List<ReorderedFolderDTO> folders;
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class ReorderedFolderDTO {
+            private Long folderId;
+            private String name;
+            private Integer sortOrder;
+        }
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/entity/Folder.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/entity/Folder.java
@@ -40,27 +40,37 @@ public class Folder {
     @JoinColumn(name = "parent_folder_id")
     private Folder parentFolder;
 
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
     public Folder(
             String fullPath,
             Integer depth,
             String name,
             Integer problemCount,
-            Folder parentFolder
+            Folder parentFolder,
+            Integer sortOrder
     ) {
         this.fullPath = fullPath;
         this.depth = depth;
         this.name = name;
         this.problemCount = problemCount;
         this.parentFolder = parentFolder;
+        this.sortOrder = sortOrder;
     }
 
-    public static Folder createChildFolder(String name, Folder parentFolder) {
+    public static Folder createChildFolder(
+            String name,
+            Folder parentFolder,
+            Integer sortOrder
+    ) {
         return new Folder(
                 buildFullPath(parentFolder, name),
                 parentFolder.getDepth() + 1,
                 name,
                 0,
-                parentFolder
+                parentFolder,
+                sortOrder
         );
     }
 
@@ -79,5 +89,22 @@ public class Folder {
             this.problemCount = 0;
         }
         this.problemCount += count;
+    }
+
+    public void rename(String name) {
+        this.name = name;
+        this.fullPath = buildFullPath(this.parentFolder, name);
+    }
+
+    public void refreshFullPath() {
+        this.fullPath = buildFullPath(this.parentFolder, this.name);
+    }
+
+    public void changeSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public boolean isRoot() {
+        return this.parentFolder == null;
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/repository/FolderRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/repository/FolderRepository.java
@@ -4,9 +4,14 @@ import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
-    List<Folder> findByParentFolder_FolderIdOrderByFolderIdAsc(Long parentFolderId);
+
+    List<Folder> findByParentFolder_FolderIdOrderBySortOrderAscFolderIdAsc(Long parentFolderId);
+
+    List<Folder> findAllByParentFolder_FolderIdOrderBySortOrderAscFolderIdAsc(Long parentFolderId);
 
     boolean existsByParentFolder(Folder parentFolder);
 
@@ -14,7 +19,19 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     boolean existsByParentFolder_FolderId(Long folderId);
 
-    List<Folder> findAllByParentFolder_FolderIdOrderByFolderIdAsc(Long parentFolderId);
-
     boolean existsByParentFolder_FolderIdAndName(Long parentFolderId, String name);
+
+    boolean existsByParentFolder_FolderIdAndNameAndFolderIdNot(
+            Long parentFolderId,
+            String name,
+            Long folderId
+    );
+
+    @Query("""
+            select coalesce(max(f.sortOrder), 0)
+            from Folder f
+            where f.parentFolder.folderId = :parentFolderId
+            """)
+    Integer findMaxSortOrderByParentFolderId(@Param("parentFolderId") Long parentFolderId);
+
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderCommandService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderCommandService.java
@@ -8,4 +8,16 @@ public interface FolderCommandService {
     FolderResponse.CreateFolderResponse createFolder(
             FolderRequest.CreateFolderRequest request
     );
+
+    FolderResponse.RenameFolderResponse renameFolder(
+            Long folderId,
+            FolderRequest.RenameFolderRequest request
+    );
+
+    FolderResponse.DeleteFolderResponse deleteFolder(Long folderId);
+
+    FolderResponse.ReorderFoldersResponse reorderChildFolders(
+            Long parentFolderId,
+            FolderRequest.ReorderFoldersRequest request
+    );
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderCommandServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderCommandServiceImpl.java
@@ -7,7 +7,14 @@ import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderRequest;
 import com.hhd1337.jatuli_quiz.domain.folder.dto.FolderResponse;
 import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
 import com.hhd1337.jatuli_quiz.domain.folder.repository.FolderRepository;
+import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
 import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +24,7 @@ import org.springframework.stereotype.Service;
 public class FolderCommandServiceImpl implements FolderCommandService {
 
     private final FolderRepository folderRepository;
+    private final ProblemRepository problemRepository;
 
     @Override
     public FolderResponse.CreateFolderResponse createFolder(
@@ -25,16 +33,101 @@ public class FolderCommandServiceImpl implements FolderCommandService {
         Folder parentFolder = folderRepository.findByFolderId(request.getParentFolderId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.FOLDER_NOT_FOUND));
 
-        validateDuplicateFolderName(parentFolder.getFolderId(), request.getName());
+        String trimmedName = request.getName().trim();
+
+        validateDuplicateFolderName(parentFolder.getFolderId(), trimmedName);
+
+        Integer nextSortOrder = folderRepository.findMaxSortOrderByParentFolderId(
+                parentFolder.getFolderId()
+        ) + 1;
 
         Folder folder = Folder.createChildFolder(
-                request.getName(),
-                parentFolder
+                trimmedName,
+                parentFolder,
+                nextSortOrder
         );
 
         Folder savedFolder = folderRepository.save(folder);
 
         return FolderConverter.toCreateFolderResponse(savedFolder);
+    }
+
+    @Override
+    public FolderResponse.RenameFolderResponse renameFolder(
+            Long folderId,
+            FolderRequest.RenameFolderRequest request
+    ) {
+        Folder folder = folderRepository.findByFolderId(folderId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.FOLDER_NOT_FOUND));
+
+        validateNotRootFolder(folder);
+
+        String trimmedName = request.getName().trim();
+
+        if (folder.getName().equals(trimmedName)) {
+            return FolderConverter.toRenameFolderResponse(folder);
+        }
+
+        Long parentFolderId = folder.getParentFolder().getFolderId();
+
+        validateDuplicateFolderNameExceptSelf(
+                parentFolderId,
+                trimmedName,
+                folder.getFolderId()
+        );
+
+        folder.rename(trimmedName);
+
+        refreshDescendantFullPaths(folder);
+
+        return FolderConverter.toRenameFolderResponse(folder);
+    }
+
+    @Override
+    public FolderResponse.DeleteFolderResponse deleteFolder(Long folderId) {
+        Folder folder = folderRepository.findByFolderId(folderId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.FOLDER_NOT_FOUND));
+
+        validateNotRootFolder(folder);
+        validateDeletableFolder(folder);
+
+        folderRepository.delete(folder);
+
+        return FolderConverter.toDeleteFolderResponse(folderId);
+    }
+
+    @Override
+    public FolderResponse.ReorderFoldersResponse reorderChildFolders(
+            Long parentFolderId,
+            FolderRequest.ReorderFoldersRequest request
+    ) {
+        Folder parentFolder = folderRepository.findByFolderId(parentFolderId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.FOLDER_NOT_FOUND));
+
+        List<Folder> childFolders =
+                folderRepository.findAllByParentFolder_FolderIdOrderBySortOrderAscFolderIdAsc(
+                        parentFolder.getFolderId()
+                );
+
+        validateReorderRequest(childFolders, request.getOrderedFolderIds());
+
+        Map<Long, Folder> folderMap = childFolders.stream()
+                .collect(Collectors.toMap(Folder::getFolderId, folder -> folder));
+
+        List<Folder> reorderedFolders = new ArrayList<>();
+
+        for (int i = 0; i < request.getOrderedFolderIds().size(); i++) {
+            Long childFolderId = request.getOrderedFolderIds().get(i);
+            Folder childFolder = folderMap.get(childFolderId);
+
+            childFolder.changeSortOrder(i + 1);
+            reorderedFolders.add(childFolder);
+        }
+
+        return FolderConverter.toReorderFoldersResponse(
+                parentFolderId,
+                reorderedFolders
+        );
     }
 
     private void validateDuplicateFolderName(Long parentFolderId, String folderName) {
@@ -45,6 +138,76 @@ public class FolderCommandServiceImpl implements FolderCommandService {
 
         if (existsSameNameFolder) {
             throw new GeneralException(ErrorStatus.DUPLICATE_FOLDER_NAME);
+        }
+    }
+
+    private void validateDuplicateFolderNameExceptSelf(
+            Long parentFolderId,
+            String folderName,
+            Long folderId
+    ) {
+        boolean existsSameNameFolder =
+                folderRepository.existsByParentFolder_FolderIdAndNameAndFolderIdNot(
+                        parentFolderId,
+                        folderName,
+                        folderId
+                );
+
+        if (existsSameNameFolder) {
+            throw new GeneralException(ErrorStatus.DUPLICATE_FOLDER_NAME);
+        }
+    }
+
+    private void validateNotRootFolder(Folder folder) {
+        if (folder.isRoot()) {
+            throw new GeneralException(ErrorStatus.ROOT_FOLDER_CANNOT_BE_MODIFIED);
+        }
+    }
+
+    private void validateDeletableFolder(Folder folder) {
+        boolean hasChildFolder = folderRepository.existsByParentFolder(folder);
+        if (hasChildFolder) {
+            throw new GeneralException(ErrorStatus.FOLDER_HAS_CHILDREN);
+        }
+
+        boolean hasProblem = problemRepository.existsByFolder(folder);
+        if (hasProblem) {
+            throw new GeneralException(ErrorStatus.FOLDER_HAS_PROBLEMS);
+        }
+    }
+
+    private void refreshDescendantFullPaths(Folder folder) {
+        List<Folder> children =
+                folderRepository.findAllByParentFolder_FolderIdOrderBySortOrderAscFolderIdAsc(
+                        folder.getFolderId()
+                );
+
+        for (Folder child : children) {
+            child.refreshFullPath();
+            refreshDescendantFullPaths(child);
+        }
+    }
+
+    private void validateReorderRequest(
+            List<Folder> childFolders,
+            List<Long> orderedFolderIds
+    ) {
+        Set<Long> existingChildFolderIds = childFolders.stream()
+                .map(Folder::getFolderId)
+                .collect(Collectors.toSet());
+
+        Set<Long> requestedFolderIds = new HashSet<>(orderedFolderIds);
+
+        if (childFolders.size() != orderedFolderIds.size()) {
+            throw new GeneralException(ErrorStatus.INVALID_FOLDER_ORDER);
+        }
+
+        if (orderedFolderIds.size() != requestedFolderIds.size()) {
+            throw new GeneralException(ErrorStatus.INVALID_FOLDER_ORDER);
+        }
+
+        if (!existingChildFolderIds.equals(requestedFolderIds)) {
+            throw new GeneralException(ErrorStatus.INVALID_FOLDER_ORDER);
         }
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderQueryServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/service/FolderQueryServiceImpl.java
@@ -34,7 +34,8 @@ public class FolderQueryServiceImpl implements FolderQueryService {
 
         List<FolderChildrenResponse.BreadcrumbDTO> breadcrumb = buildBreadcrumb(currentFolder);
 
-        List<Folder> childFolders = folderRepository.findByParentFolder_FolderIdOrderByFolderIdAsc(folderId);
+        List<Folder> childFolders =
+                folderRepository.findByParentFolder_FolderIdOrderBySortOrderAscFolderIdAsc(folderId);
 
         List<FolderChildrenResponse.FolderDTO> folders = childFolders.stream()
                 .map(this::toFolderDTO)
@@ -71,8 +72,11 @@ public class FolderQueryServiceImpl implements FolderQueryService {
         int total = problemRepository.countByFolder(folder);
         int solved = problemRepository.countByFolderAndSolvedCountGreaterThan(folder, 0);
 
-        List<Folder> children = folderRepository.findByParentFolder_FolderIdOrderByFolderIdAsc(folder.getFolderId());
-
+        List<Folder> children =
+                folderRepository.findByParentFolder_FolderIdOrderBySortOrderAscFolderIdAsc(
+                        folder.getFolderId()
+                );
+        
         for (Folder child : children) {
             FolderStats childStats = calculateFolderStats(child);
             total += childStats.total();

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/service/HomeQueryServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/home/service/HomeQueryServiceImpl.java
@@ -75,7 +75,7 @@ public class HomeQueryServiceImpl implements HomeQueryService {
                 getBookmarkCycleProgress(learningProgress);
 
         List<Folder> rootFolders =
-                folderRepository.findAllByParentFolder_FolderIdOrderByFolderIdAsc(ROOT_FOLDER_ID);
+                folderRepository.findAllByParentFolder_FolderIdOrderBySortOrderAscFolderIdAsc(ROOT_FOLDER_ID);
 
         List<HomeResponse.RootFolderItem> rootFolderItems = rootFolders.stream()
                 .map(this::buildFolderTreeItem)
@@ -135,7 +135,7 @@ public class HomeQueryServiceImpl implements HomeQueryService {
         int ownSolvedProblemCount = problemRepository.countByFolderAndSolvedCountGreaterThan(folder, 0);
 
         List<Folder> childFolders =
-                folderRepository.findAllByParentFolder_FolderIdOrderByFolderIdAsc(folder.getFolderId());
+                folderRepository.findAllByParentFolder_FolderIdOrderBySortOrderAscFolderIdAsc(folder.getFolderId());
 
         List<FolderTreeBuildResult> childResults = childFolders.stream()
                 .map(this::buildFolderTreeItem)

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
@@ -111,4 +111,6 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
     );
 
     int countByIsBookmarkedTrueAndLastPracticedBookmarkedRoundNoGreaterThanEqual(Integer roundNo);
+
+    boolean existsByFolder(Folder folder);
 }

--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -1,7 +1,12 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getHomeData } from "../../shared/api/homeApi";
-import { createFolder } from "../../shared/api/folderApi";
+import {
+    createFolder,
+    renameFolder,
+    deleteFolder,
+    reorderChildFolders,
+} from "../../shared/api/folderApi";
 import { importProblemsText } from "../../shared/api/quizApi";
 
 const pageStyle = {
@@ -398,6 +403,14 @@ function FolderTreeItem({
                             parentFolderId = null,
                             isManageMode,
 
+                            siblings = [],
+                            indexInSiblings = 0,
+                            orderParentFolderId,
+
+                            onRenameFolder,
+                            onDeleteFolder,
+                            onMoveFolder,
+
                             creatingParentFolder,
                             newFolderName,
                             setNewFolderName,
@@ -423,6 +436,8 @@ function FolderTreeItem({
     const totalCount = Number(folder.totalCount ?? 0);
     const hasOwnProblems = isLeaf && totalCount > 0;
     const canAddChildFolder = !hasOwnProblems;
+    const canMoveUp = indexInSiblings > 0;
+    const canMoveDown = indexInSiblings < siblings.length - 1;
 
     function handleClick() {
         if (hasChildren) {
@@ -595,30 +610,73 @@ function FolderTreeItem({
 
                                     <button
                                         type="button"
-                                        onClick={() => alert("폴더 이름 변경 API가 아직 없습니다.")}
+                                        onClick={() => onRenameFolder(folder)}
+                                        disabled={submitting}
                                         style={{
                                             ...folderActionButtonStyle,
                                             width: "100%",
                                             borderRadius: 8,
-                                            opacity: 0.5,
-                                            cursor: "not-allowed",
                                         }}
                                     >
-                                        이름 변경 준비중
+                                        이름 변경
                                     </button>
 
                                     <button
                                         type="button"
-                                        onClick={() => alert("폴더 삭제 API가 아직 없습니다.")}
+                                        onClick={() =>
+                                            onMoveFolder({
+                                                parentFolderId: orderParentFolderId,
+                                                siblings,
+                                                fromIndex: indexInSiblings,
+                                                direction: "UP",
+                                            })
+                                        }
+                                        disabled={!canMoveUp || submitting}
                                         style={{
                                             ...folderActionButtonStyle,
                                             width: "100%",
                                             borderRadius: 8,
-                                            opacity: 0.5,
-                                            cursor: "not-allowed",
+                                            opacity: canMoveUp ? 1 : 0.45,
+                                            cursor: canMoveUp ? "pointer" : "not-allowed",
                                         }}
                                     >
-                                        삭제 준비중
+                                        위로 이동
+                                    </button>
+
+                                    <button
+                                        type="button"
+                                        onClick={() =>
+                                            onMoveFolder({
+                                                parentFolderId: orderParentFolderId,
+                                                siblings,
+                                                fromIndex: indexInSiblings,
+                                                direction: "DOWN",
+                                            })
+                                        }
+                                        disabled={!canMoveDown || submitting}
+                                        style={{
+                                            ...folderActionButtonStyle,
+                                            width: "100%",
+                                            borderRadius: 8,
+                                            opacity: canMoveDown ? 1 : 0.45,
+                                            cursor: canMoveDown ? "pointer" : "not-allowed",
+                                        }}
+                                    >
+                                        아래로 이동
+                                    </button>
+
+                                    <button
+                                        type="button"
+                                        onClick={() => onDeleteFolder(folder)}
+                                        disabled={submitting}
+                                        style={{
+                                            ...folderActionButtonStyle,
+                                            width: "100%",
+                                            borderRadius: 8,
+                                            color: "#fca5a5",
+                                        }}
+                                    >
+                                        삭제
                                     </button>
                                 </div>
                             )}
@@ -682,7 +740,7 @@ function FolderTreeItem({
                         borderLeft: "1px solid var(--color-border)",
                     }}
                 >
-                    {children.map((child) => (
+                    {children.map((child, index) => (
                         <FolderTreeItem
                             key={child.folderId}
                             folder={child}
@@ -693,6 +751,14 @@ function FolderTreeItem({
                             pathNames={currentPathNames}
                             parentFolderId={folder.folderId}
                             isManageMode={isManageMode}
+
+                            siblings={children}
+                            indexInSiblings={index}
+                            orderParentFolderId={folder.folderId}
+
+                            onRenameFolder={onRenameFolder}
+                            onDeleteFolder={onDeleteFolder}
+                            onMoveFolder={onMoveFolder}
 
                             creatingParentFolder={creatingParentFolder}
                             newFolderName={newFolderName}
@@ -730,6 +796,7 @@ function collectFolderIdsWithChildren(folders = []) {
 }
 
 const COLLAPSED_FOLDER_IDS_STORAGE_KEY = "jatuli.home.collapsedFolderIds";
+const ROOT_FOLDER_ID = 1;
 
 function readCollapsedFolderIdsFromStorage() {
     try {
@@ -763,6 +830,21 @@ function saveCollapsedFolderIdsToStorage(collapsedFolderIds) {
     } catch (error) {
         console.error("폴더 접힘 상태 저장 실패:", error);
     }
+}
+
+function getApiErrorMessage(error, fallbackMessage) {
+    return (
+        error?.response?.data?.message ||
+        error?.response?.data?.result?.message ||
+        fallbackMessage
+    );
+}
+
+function moveItem(array, fromIndex, toIndex) {
+    const copied = [...array];
+    const [removed] = copied.splice(fromIndex, 1);
+    copied.splice(toIndex, 0, removed);
+    return copied;
 }
 
 export default function HomePage() {
@@ -868,6 +950,114 @@ export default function HomePage() {
         } catch (err) {
             console.error("폴더 추가 실패:", err);
             alert("폴더 추가에 실패했습니다.");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    async function handleRenameFolder(folder) {
+        const nextName = window.prompt("새 폴더 이름을 입력하세요.", folder.name);
+
+        if (nextName === null) return;
+
+        const trimmedName = nextName.trim();
+
+        if (!trimmedName) {
+            alert("폴더 이름을 입력해주세요.");
+            return;
+        }
+
+        if (trimmedName === folder.name) {
+            setOpenedMenuFolderId(null);
+            return;
+        }
+
+        try {
+            setSubmitting(true);
+            setOpenedMenuFolderId(null);
+
+            await renameFolder({
+                folderId: folder.folderId,
+                name: trimmedName,
+            });
+
+            await fetchHomeData();
+        } catch (err) {
+            console.error("폴더 이름 변경 실패:", err);
+            alert(getApiErrorMessage(err, "폴더 이름 변경에 실패했습니다."));
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    async function handleDeleteFolder(folder) {
+        const hasChildren = Array.isArray(folder.children) && folder.children.length > 0;
+        const totalCount = Number(folder.totalCount ?? 0);
+
+        if (hasChildren) {
+            alert("하위 폴더가 있는 폴더는 삭제할 수 없습니다.");
+            return;
+        }
+
+        if (totalCount > 0) {
+            alert("문제가 있는 폴더는 삭제할 수 없습니다.");
+            return;
+        }
+
+        const confirmed = window.confirm(
+            `'${folder.name}' 폴더를 삭제할까요?`
+        );
+
+        if (!confirmed) return;
+
+        try {
+            setSubmitting(true);
+            setOpenedMenuFolderId(null);
+
+            await deleteFolder(folder.folderId);
+
+            await fetchHomeData();
+        } catch (err) {
+            console.error("폴더 삭제 실패:", err);
+            alert(getApiErrorMessage(err, "폴더 삭제에 실패했습니다."));
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    async function handleMoveFolder({
+                                        parentFolderId,
+                                        siblings,
+                                        fromIndex,
+                                        direction,
+                                    }) {
+        if (!parentFolderId) {
+            alert("부모 폴더 정보를 찾을 수 없습니다.");
+            return;
+        }
+
+        const toIndex = direction === "UP" ? fromIndex - 1 : fromIndex + 1;
+
+        if (toIndex < 0 || toIndex >= siblings.length) {
+            return;
+        }
+
+        const reorderedFolders = moveItem(siblings, fromIndex, toIndex);
+        const orderedFolderIds = reorderedFolders.map((folder) => folder.folderId);
+
+        try {
+            setSubmitting(true);
+            setOpenedMenuFolderId(null);
+
+            await reorderChildFolders({
+                parentFolderId,
+                orderedFolderIds,
+            });
+
+            await fetchHomeData();
+        } catch (err) {
+            console.error("폴더 순서 변경 실패:", err);
+            alert(getApiErrorMessage(err, "폴더 순서 변경에 실패했습니다."));
         } finally {
             setSubmitting(false);
         }
@@ -1361,6 +1551,14 @@ export default function HomePage() {
                                     pathNames={[]}
                                     parentFolderId={null}
                                     isManageMode={isManageMode}
+
+                                    siblings={rootFolders}
+                                    indexInSiblings={index}
+                                    orderParentFolderId={ROOT_FOLDER_ID}
+
+                                    onRenameFolder={handleRenameFolder}
+                                    onDeleteFolder={handleDeleteFolder}
+                                    onMoveFolder={handleMoveFolder}
 
                                     creatingParentFolder={creatingParentFolder}
                                     newFolderName={newFolderName}

--- a/frontend/src/shared/api/folderApi.js
+++ b/frontend/src/shared/api/folderApi.js
@@ -39,6 +39,7 @@ function normalizeFolderChildren(raw) {
                         0
                     ),
                     isLeaf: folder.isLeaf ?? !folder.hasChildren,
+                    sortOrder: folder.sortOrder ?? null,
                 })),
             },
         ],
@@ -64,6 +65,31 @@ export async function createFolder({ parentFolderId, name }) {
         parentFolderId,
         name,
     });
+
+    return response.data.result;
+}
+
+export async function renameFolder({ folderId, name }) {
+    const response = await apiClient.patch(`/api/v1/folders/${folderId}/name`, {
+        name,
+    });
+
+    return response.data.result;
+}
+
+export async function deleteFolder(folderId) {
+    const response = await apiClient.delete(`/api/v1/folders/${folderId}`);
+
+    return response.data.result;
+}
+
+export async function reorderChildFolders({ parentFolderId, orderedFolderIds }) {
+    const response = await apiClient.patch(
+        `/api/v1/folders/${parentFolderId}/children/order`,
+        {
+            orderedFolderIds,
+        }
+    );
 
     return response.data.result;
 }


### PR DESCRIPTION
## 📝 작업 내용 설명

폴더 이름 변경, 삭제, 순서 변경 기능을 사용할 수 있도록 백엔드 API를 구현하고 프론트엔드 관리 모드에 연동했습니다.

이를 통해 사용자가 홈 화면에서 직접 폴더 구조를 관리할 수 있도록 개선했습니다.

## ✅ 작업 내용

* [x] 폴더 이름 변경 API 구현
* [x] 폴더 삭제 API 구현
* [x] 폴더 순서 변경 API 구현
* [x] 폴더 관리 API 프론트엔드 연동
* [x] 관리 모드 폴더 메뉴 기능 수정

## 🔍 주요 변경 포인트

* 같은 부모 폴더 내 중복 이름 검증 추가
* 루트 폴더 수정/삭제 제한 처리
* 하위 폴더 또는 문제가 있는 폴더 삭제 제한 처리
* `sortOrder` 기반 폴더 정렬 및 순서 변경 처리
* 폴더 관리 메뉴에서 이름 변경, 삭제, 위/아래 이동 기능 제공

## 🧪 확인한 내용

* [x] 로컬 환경에서 정상 동작 확인
* [x] Swagger에서 폴더 관리 API 요청/응답 확인
* [x] 프론트엔드에서 폴더 이름 변경 동작 확인
* [x] 프론트엔드에서 폴더 삭제 동작 확인
* [x] 프론트엔드에서 폴더 순서 변경 동작 확인
* [x] 기존 폴더 조회 및 문제 풀이 이동 기능 확인

## 📌 비고

* 폴더 삭제는 현재 하위 폴더나 문제가 없는 경우에만 가능합니다.
* 폴더 순서 변경은 같은 부모 폴더 내 위/아래 이동 방식으로 구현했습니다.

## 🔗 관련 이슈

closes #60
