### PR TITLE
feat(fullstack/practice): 폴더별 문제풀이 이어풀기 커서 구현

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/WebConfig.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/WebConfig.java
@@ -1,5 +1,7 @@
 package com.hhd1337.jatuli_quiz.config;
 
+import java.util.Arrays;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,19 +9,18 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    @Value("${app.cors.allowed-origins}")
+    private String allowedOrigins;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
+        String[] origins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(origin -> !origin.isBlank())
+                .toArray(String[]::new);
+
         registry.addMapping("/**")
-                .allowedOrigins(
-                        "http://localhost:3000",
-                        "http://localhost:5173",
-                        "http://10.30.5.111:5173",
-                        "http://192.168.0.26:5173",
-                        "https://jatuli.online",
-                        "https://www.jatuli.online",
-                        "https://jatuli-quiz-frontend.vercel.app",
-                        "https://api.jatuli.online"
-                )
+                .allowedOrigins(origins)
                 .allowedMethods("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(false);

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/controller/FolderPracticeCursorController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/controller/FolderPracticeCursorController.java
@@ -1,0 +1,42 @@
+package com.hhd1337.jatuli_quiz.domain.practice.controller;
+
+import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
+import com.hhd1337.jatuli_quiz.domain.practice.dto.FolderPracticeCursorResponse;
+import com.hhd1337.jatuli_quiz.domain.practice.service.FolderPracticeCursorService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FolderPracticeCursorController {
+
+    private final FolderPracticeCursorService folderPracticeCursorService;
+
+    @Operation(
+            summary = "폴더별 문제풀이 진행 커서 조회",
+            description = """
+                    특정 폴더의 문제풀이 진행 커서를 조회합니다.
+                    
+                    폴더별 문제풀이에서 사용자가 이전에 제출한 기록이 있는 경우,
+                    다음에 이어서 풀 문제의 위치 정보를 반환합니다.
+                    
+                    프론트엔드는 이 API 응답의 hasCursor 값을 기준으로
+                    사용자에게 "이어서 풀까요?" 알림창을 표시할 수 있습니다.
+                    
+                    - hasCursor가 false이면 저장된 진행 위치가 없으므로 1번 문제부터 시작합니다.
+                    - hasCursor가 true이면 nextProblemIndex 또는 nextProblemNumber를 기준으로 이어서 풀 수 있습니다.
+                    - 북마크 문제 전체 순회는 별도 학습 흐름이므로 이 커서 조회 대상에 포함되지 않습니다.
+                    """
+    )
+    @GetMapping("/api/v1/folders/{folderId}/practice-cursor")
+    public ApiResponse<FolderPracticeCursorResponse> getFolderPracticeCursor(
+            @PathVariable Long folderId
+    ) {
+        FolderPracticeCursorResponse response = folderPracticeCursorService.getCursor(folderId);
+
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/controller/PracticeRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/controller/PracticeRestController.java
@@ -1,4 +1,4 @@
-package com.hhd1337.jatuli_quiz.domain.practice;
+package com.hhd1337.jatuli_quiz.domain.practice.controller;
 
 import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
 import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/dto/FolderPracticeCursorResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/dto/FolderPracticeCursorResponse.java
@@ -1,0 +1,34 @@
+package com.hhd1337.jatuli_quiz.domain.practice.dto;
+
+public record FolderPracticeCursorResponse(
+        boolean hasCursor,
+        Long nextProblemId,
+        int nextProblemIndex,
+        int nextProblemNumber,
+        int totalProblemCount
+) {
+
+    public static FolderPracticeCursorResponse noCursor(int totalProblemCount) {
+        return new FolderPracticeCursorResponse(
+                false,
+                null,
+                0,
+                1,
+                totalProblemCount
+        );
+    }
+
+    public static FolderPracticeCursorResponse of(
+            Long nextProblemId,
+            int nextProblemIndex,
+            int totalProblemCount
+    ) {
+        return new FolderPracticeCursorResponse(
+                true,
+                nextProblemId,
+                nextProblemIndex,
+                nextProblemIndex + 1,
+                totalProblemCount
+        );
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/entity/FolderPracticeCursor.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/entity/FolderPracticeCursor.java
@@ -1,0 +1,74 @@
+package com.hhd1337.jatuli_quiz.domain.practice.entity;
+
+import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "folder_practice_cursor",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_folder_practice_cursor_folder_id",
+                        columnNames = "folder_id"
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FolderPracticeCursor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cursor_id")
+    private Long cursorId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "folder_id", nullable = false)
+    private Folder folder;
+
+    @Column(name = "next_problem_id")
+    private Long nextProblemId;
+
+    @Column(name = "last_submitted_problem_id")
+    private Long lastSubmittedProblemId;
+
+    private FolderPracticeCursor(
+            Folder folder,
+            Long nextProblemId,
+            Long lastSubmittedProblemId
+    ) {
+        this.folder = folder;
+        this.nextProblemId = nextProblemId;
+        this.lastSubmittedProblemId = lastSubmittedProblemId;
+    }
+
+    public static FolderPracticeCursor create(Folder folder, Long nextProblemId) {
+        return new FolderPracticeCursor(
+                folder,
+                nextProblemId,
+                null
+        );
+    }
+
+    public void updateCursor(Long submittedProblemId, Long nextProblemId) {
+        this.lastSubmittedProblemId = submittedProblemId;
+        this.nextProblemId = nextProblemId;
+    }
+
+    public void resetToFirstProblem(Long firstProblemId) {
+        this.lastSubmittedProblemId = null;
+        this.nextProblemId = firstProblemId;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/entity/PracticeMode.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/entity/PracticeMode.java
@@ -1,0 +1,6 @@
+package com.hhd1337.jatuli_quiz.domain.practice.entity;
+
+public enum PracticeMode {
+    FOLDER,
+    BOOKMARKED
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/repository/FolderPracticeCursorRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/repository/FolderPracticeCursorRepository.java
@@ -1,0 +1,10 @@
+package com.hhd1337.jatuli_quiz.domain.practice.repository;
+
+import com.hhd1337.jatuli_quiz.domain.practice.entity.FolderPracticeCursor;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FolderPracticeCursorRepository extends JpaRepository<FolderPracticeCursor, Long> {
+
+    Optional<FolderPracticeCursor> findByFolder_FolderId(Long folderId);
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/FolderPracticeCursorService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/FolderPracticeCursorService.java
@@ -69,7 +69,10 @@ public class FolderPracticeCursorService {
         int submittedProblemIndex = findProblemIndex(problems, submittedProblemId);
 
         if (submittedProblemIndex == -1) {
-            return;
+            throw new IllegalArgumentException(
+                    "제출한 문제가 해당 폴더에 속하지 않습니다. folderId="
+                            + folderId + ", problemId=" + submittedProblemId
+            );
         }
 
         int nextProblemIndex = submittedProblemIndex + 1;
@@ -82,7 +85,9 @@ public class FolderPracticeCursorService {
 
         FolderPracticeCursor cursor = folderPracticeCursorRepository
                 .findByFolder_FolderId(folderId)
-                .orElseGet(() -> FolderPracticeCursor.create(folder, nextProblemId));
+                .orElseGet(() -> folderPracticeCursorRepository.save(
+                        FolderPracticeCursor.create(folder, nextProblemId)
+                ));
 
         cursor.updateCursor(submittedProblemId, nextProblemId);
     }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/FolderPracticeCursorService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/practice/service/FolderPracticeCursorService.java
@@ -1,0 +1,99 @@
+package com.hhd1337.jatuli_quiz.domain.practice.service;
+
+import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
+import com.hhd1337.jatuli_quiz.domain.folder.repository.FolderRepository;
+import com.hhd1337.jatuli_quiz.domain.practice.dto.FolderPracticeCursorResponse;
+import com.hhd1337.jatuli_quiz.domain.practice.entity.FolderPracticeCursor;
+import com.hhd1337.jatuli_quiz.domain.practice.repository.FolderPracticeCursorRepository;
+import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FolderPracticeCursorService {
+
+    private final FolderPracticeCursorRepository folderPracticeCursorRepository;
+    private final FolderRepository folderRepository;
+    private final ProblemRepository problemRepository;
+
+    @Transactional(readOnly = true)
+    public FolderPracticeCursorResponse getCursor(Long folderId) {
+        List<Problem> problems = problemRepository.findByFolder_FolderIdOrderByProblemIdAsc(folderId);
+
+        if (problems.isEmpty()) {
+            return FolderPracticeCursorResponse.noCursor(0);
+        }
+
+        Optional<FolderPracticeCursor> cursorOptional =
+                folderPracticeCursorRepository.findByFolder_FolderId(folderId);
+
+        if (cursorOptional.isEmpty()) {
+            return FolderPracticeCursorResponse.noCursor(problems.size());
+        }
+
+        FolderPracticeCursor cursor = cursorOptional.get();
+
+        if (cursor.getNextProblemId() == null) {
+            return FolderPracticeCursorResponse.noCursor(problems.size());
+        }
+
+        int nextProblemIndex = findProblemIndex(problems, cursor.getNextProblemId());
+
+        if (nextProblemIndex == -1) {
+            return FolderPracticeCursorResponse.noCursor(problems.size());
+        }
+
+        return FolderPracticeCursorResponse.of(
+                cursor.getNextProblemId(),
+                nextProblemIndex,
+                problems.size()
+        );
+    }
+
+    @Transactional
+    public void updateAfterSubmit(Long folderId, Long submittedProblemId) {
+        Folder folder = folderRepository.findById(folderId)
+                .orElseThrow(() -> new IllegalArgumentException("폴더를 찾을 수 없습니다. folderId=" + folderId));
+
+        List<Problem> problems = problemRepository.findByFolder_FolderIdOrderByProblemIdAsc(folderId);
+
+        if (problems.isEmpty()) {
+            return;
+        }
+
+        int submittedProblemIndex = findProblemIndex(problems, submittedProblemId);
+
+        if (submittedProblemIndex == -1) {
+            return;
+        }
+
+        int nextProblemIndex = submittedProblemIndex + 1;
+
+        if (nextProblemIndex >= problems.size()) {
+            nextProblemIndex = 0;
+        }
+
+        Long nextProblemId = problems.get(nextProblemIndex).getProblemId();
+
+        FolderPracticeCursor cursor = folderPracticeCursorRepository
+                .findByFolder_FolderId(folderId)
+                .orElseGet(() -> FolderPracticeCursor.create(folder, nextProblemId));
+
+        cursor.updateCursor(submittedProblemId, nextProblemId);
+    }
+
+    private int findProblemIndex(List<Problem> problems, Long problemId) {
+        for (int i = 0; i < problems.size(); i++) {
+            if (problems.get(i).getProblemId().equals(problemId)) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
@@ -113,4 +113,6 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
     int countByIsBookmarkedTrueAndLastPracticedBookmarkedRoundNoGreaterThanEqual(Integer roundNo);
 
     boolean existsByFolder(Folder folder);
+
+    List<Problem> findByFolder_FolderIdOrderByProblemIdAsc(Long folderId);
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/ProblemSubmissionRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/ProblemSubmissionRestController.java
@@ -9,11 +9,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/problem-submissions")
 @RequiredArgsConstructor
 public class ProblemSubmissionRestController {
 
@@ -29,7 +27,7 @@ public class ProblemSubmissionRestController {
                     오늘 첫 제출인 경우 daysInARow도 함께 갱신합니다.
                     """
     )
-    @PostMapping
+    @PostMapping("/api/v1/problem-submissions")
     public ApiResponse<ProblemSubmissionResponse.CreateProblemSubmissionResponse> submit(
             @Valid @RequestBody ProblemSubmissionRequest.CreateProblemSubmissionRequest request
     ) {

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/dto/ProblemSubmissionRequest.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/dto/ProblemSubmissionRequest.java
@@ -1,11 +1,13 @@
 package com.hhd1337.jatuli_quiz.domain.problemsubmission.dto;
 
+import com.hhd1337.jatuli_quiz.domain.practice.entity.PracticeMode;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class ProblemSubmissionRequest {
+
     @Getter
     @NoArgsConstructor
     public static class CreateProblemSubmissionRequest {
@@ -17,5 +19,17 @@ public class ProblemSubmissionRequest {
 
         @PositiveOrZero
         private Integer elapsedSeconds;
+
+        private PracticeMode practiceMode;
+
+        private Long folderId;
+
+        public boolean isFolderPracticeMode() {
+            return PracticeMode.FOLDER.equals(this.practiceMode);
+        }
+
+        public boolean isBookmarkedPracticeMode() {
+            return PracticeMode.BOOKMARKED.equals(this.practiceMode);
+        }
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/service/ProblemSubmissionCommandServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/service/ProblemSubmissionCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.hhd1337.jatuli_quiz.common.exception.GeneralException;
 import com.hhd1337.jatuli_quiz.common.exception.code.status.ErrorStatus;
 import com.hhd1337.jatuli_quiz.domain.dailystat.entity.DailyStat;
 import com.hhd1337.jatuli_quiz.domain.dailystat.repository.DailyStatRepository;
+import com.hhd1337.jatuli_quiz.domain.practice.service.FolderPracticeCursorService;
 import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
 import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
 import com.hhd1337.jatuli_quiz.domain.problemsubmission.converter.ProblemSubmissionConverter;
@@ -32,6 +33,7 @@ public class ProblemSubmissionCommandServiceImpl implements ProblemSubmissionCom
     private final ProblemSubmissionRepository problemSubmissionRepository;
     private final DailyStatRepository dailyStatRepository;
     private final LearningProgressRepository learningProgressRepository;
+    private final FolderPracticeCursorService folderPracticeCursorService;
 
     @Override
     public ProblemSubmissionResponse.CreateProblemSubmissionResponse submit(
@@ -40,16 +42,22 @@ public class ProblemSubmissionCommandServiceImpl implements ProblemSubmissionCom
         Problem problem = problemRepository.findById(request.getProblemId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PROBLEM_NOT_FOUND));
 
-        LearningProgress learningProgress = getOrCreateSingleUserLearningProgressWithLock();
-        Integer currentRoundNo = learningProgress.getCurrentBookmarkedRoundNo();
-
         int elapsedSeconds = request.getElapsedSeconds() == null ? 0 : request.getElapsedSeconds();
 
-        boolean isBookmarkedSubmission = Boolean.TRUE.equals(problem.getIsBookmarked());
+        boolean isBookmarkedPracticeSubmission =
+                request.isBookmarkedPracticeMode() && Boolean.TRUE.equals(problem.getIsBookmarked());
+
+        LearningProgress learningProgress = null;
+        Integer currentRoundNo = null;
+
+        if (isBookmarkedPracticeSubmission) {
+            learningProgress = getOrCreateSingleUserLearningProgressWithLock();
+            currentRoundNo = learningProgress.getCurrentBookmarkedRoundNo();
+        }
 
         problem.increaseSolvedCount();
 
-        if (isBookmarkedSubmission) {
+        if (isBookmarkedPracticeSubmission) {
             problem.markPracticedInBookmarkedRound(currentRoundNo);
         }
 
@@ -63,12 +71,29 @@ public class ProblemSubmissionCommandServiceImpl implements ProblemSubmissionCom
 
         DailyStat dailyStat = updateDailyStat(elapsedSeconds);
 
-        if (isBookmarkedSubmission) {
+        if (request.isFolderPracticeMode()) {
+            updateFolderPracticeCursor(request);
+        }
+
+        if (isBookmarkedPracticeSubmission) {
             problemRepository.flush();
             completeBookmarkedRoundIfNeeded(learningProgress, currentRoundNo);
         }
 
         return ProblemSubmissionConverter.toCreateProblemSubmissionResponse(problem, dailyStat);
+    }
+
+    private void updateFolderPracticeCursor(
+            ProblemSubmissionRequest.CreateProblemSubmissionRequest request
+    ) {
+        if (request.getFolderId() == null) {
+            throw new GeneralException(ErrorStatus.FOLDER_NOT_FOUND);
+        }
+
+        folderPracticeCursorService.updateAfterSubmit(
+                request.getFolderId(),
+                request.getProblemId()
+        );
     }
 
     private LearningProgress getOrCreateSingleUserLearningProgressWithLock() {

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -12,3 +12,11 @@ spring:
     properties:
       hibernate:
         format_sql: false
+
+app:
+  cors:
+    allowed-origins: >
+      https://jatuli.online,
+      https://www.jatuli.online,
+      https://jatuli-quiz-frontend.vercel.app,
+      https://api.jatuli.online

--- a/frontend/src/pages/quiz/QuizPlayPage.jsx
+++ b/frontend/src/pages/quiz/QuizPlayPage.jsx
@@ -7,6 +7,7 @@ import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { getFolderPractice } from "../../shared/api/folderApi";
 import {
     getBookmarkedPractice,
+    getFolderPracticeCursor,
     submitProblemSubmission,
     toggleProblemBookmark,
 } from "../../shared/api/quizApi";
@@ -174,7 +175,9 @@ const nextSplashTextStyle = {
     color: "var(--color-text, #f9fafb)",
 };
 
-function getButtonStyle(disabled = false) {
+function getButtonStyle(disabled = false, size = "normal") {
+    const isSmall = size === "small";
+
     return {
         border: "1px solid var(--color-border, #374151)",
         background: disabled
@@ -183,12 +186,15 @@ function getButtonStyle(disabled = false) {
         color: disabled
             ? "var(--color-button-disabled-text, #6b7280)"
             : "var(--color-button-text, #f9fafb)",
-        padding: "6px 10px",
+        padding: isSmall ? "6px 8px" : "6px 10px",
         borderRadius: 6,
         cursor: disabled ? "not-allowed" : "pointer",
         opacity: disabled ? 0.65 : 1,
-        width: 80,
+        minWidth: isSmall ? 45 : 80,
+        width: "auto",
         height: 35,
+        fontSize: isSmall ? 13 : 14,
+        whiteSpace: "nowrap",
     };
 }
 
@@ -465,6 +471,51 @@ export default function QuizPlayPage() {
 
     const problems = localProblems;
 
+    const resolveFolderStartIndex = async (targetFolderId, fetchedProblems) => {
+        if (!targetFolderId || fetchedProblems.length === 0) {
+            return 0;
+        }
+
+        try {
+            const cursor = await getFolderPracticeCursor(targetFolderId);
+
+            if (!cursor.hasCursor) {
+                return 0;
+            }
+
+            const safeCursorIndex = Math.min(
+                Math.max(Number(cursor.nextProblemIndex) || 0, 0),
+                fetchedProblems.length - 1
+            );
+
+            const shouldContinue = window.confirm(
+                `${cursor.nextProblemNumber}번 문제부터 이어서 풀까요?\n\n확인: 이어서 풀기\n취소: 처음부터 풀기`
+            );
+
+            return shouldContinue ? safeCursorIndex : 0;
+        } catch (cursorError) {
+            console.warn("폴더별 커서 조회 실패:", cursorError);
+            return 0;
+        }
+    };
+
+    const getSubmissionContext = () => {
+        if (isBookmarkMode) {
+            return {
+                practiceMode: "BOOKMARKED",
+            };
+        }
+
+        if (isFolderPracticeMode) {
+            return {
+                practiceMode: "FOLDER",
+                folderId: Number(folderId),
+            };
+        }
+
+        return {};
+    };
+
     useEffect(() => {
         let ignore = false;
 
@@ -535,8 +586,12 @@ export default function QuizPlayPage() {
                     if (ignore) return;
 
                     const fetchedProblems = data.problems ?? [];
+                    const startIndex = await resolveFolderStartIndex(folderId, fetchedProblems);
+
+                    if (ignore) return;
 
                     setLocalProblems(fetchedProblems);
+                    setCurrentIndex(startIndex);
                     setTitlePath(
                         getPracticeTitlePath(data, initialTitlePath || "문제 풀이")
                     );
@@ -563,7 +618,33 @@ export default function QuizPlayPage() {
 
                 if (ignore) return;
 
-                setLocalProblems(data.problems ?? []);
+                const fetchedProblems = data.problems ?? [];
+
+                let startIndex = 0;
+
+                try {
+                    const cursor = await getFolderPracticeCursor(folderId);
+
+                    if (!ignore && cursor.hasCursor && fetchedProblems.length > 0) {
+                        const safeCursorIndex = Math.min(
+                            Math.max(Number(cursor.nextProblemIndex) || 0, 0),
+                            fetchedProblems.length - 1
+                        );
+
+                        const shouldContinue = window.confirm(
+                            `${cursor.nextProblemNumber}번 문제부터 이어서 풀까요?\n\n확인: 이어서 풀기\n취소: 처음부터 풀기`
+                        );
+
+                        if (shouldContinue) {
+                            startIndex = safeCursorIndex;
+                        }
+                    }
+                } catch (cursorError) {
+                    console.warn("폴더별 커서 조회 실패:", cursorError);
+                }
+
+                setLocalProblems(fetchedProblems);
+                setCurrentIndex(startIndex);
                 setTitlePath(
                     getPracticeTitlePath(data, initialTitlePath || "문제 풀이")
                 );
@@ -797,6 +878,7 @@ export default function QuizPlayPage() {
                 problemId: problem.problemId,
                 isCorrect: true,
                 elapsedSeconds,
+                ...getSubmissionContext(),
             });
 
             setSubmittedProblemIds((prev) => {
@@ -864,13 +946,19 @@ export default function QuizPlayPage() {
         setShowAnswer((prev) => !prev);
     };
 
-    const handleNextClick = async () => {
-        if (submitting) return;
+    const handleSkipNextClick = () => {
+        if (submitting || nextSplashOpen) return;
+
+        goNext();
+    };
+
+    const handleSubmitAndNextClick = async () => {
+        if (submitting || nextSplashOpen) return;
 
         const problem = problems[currentIndex];
 
         if (submittedProblemIds.has(problem?.problemId)) {
-            goNext();
+            goNextWithSplash();
             return;
         }
 
@@ -1021,8 +1109,8 @@ export default function QuizPlayPage() {
     const { parentPath, currentTitle } = splitTitlePath(currentTitlePath);
 
     const isPrevDisabled = currentIndex === 0 || submitting || nextSplashOpen;
-    const isNextDisabled = submitting || nextSplashOpen;
-    const isExitDisabled = submitting || nextSplashOpen;
+    const isSkipNextDisabled = submitting || nextSplashOpen;
+    const isSubmitNextDisabled = submitting || nextSplashOpen;
 
     return (
         <div
@@ -1174,27 +1262,28 @@ export default function QuizPlayPage() {
                 style={bottomLeftControlsStyle}
             >
                 <button
-                    style={getButtonStyle(isPrevDisabled)}
+                    style={getButtonStyle(isPrevDisabled, "small")}
                     onClick={goPrev}
                     disabled={isPrevDisabled}
                 >
-                    이전 문제
+                    &lt; 이전
                 </button>
 
                 <button
-                    style={getButtonStyle(isNextDisabled)}
-                    onClick={handleNextClick}
-                    disabled={isNextDisabled}
+                    style={getButtonStyle(isSkipNextDisabled, "small")}
+                    onClick={handleSkipNextClick}
+                    disabled={isSkipNextDisabled}
                 >
-                    {submitting ? "제출 중..." : "다음 문제"}
+                    다음 &gt;
                 </button>
 
-                {/*<button*/}
-                {/*    style={getButtonStyle(false)}*/}
-                {/*    onClick={handleSpeakAnswer}*/}
-                {/*>*/}
-                {/*    {isSpeaking ? "읽기 중지" : "정답 읽기"}*/}
-                {/*</button>*/}
+                <button
+                    style={getButtonStyle(isSubmitNextDisabled)}
+                    onClick={handleSubmitAndNextClick}
+                    disabled={isSubmitNextDisabled}
+                >
+                    {submitting ? "제출 중..." : "제출 후 다음"}
+                </button>
             </div>
 
             <div

--- a/frontend/src/shared/api/quizApi.js
+++ b/frontend/src/shared/api/quizApi.js
@@ -18,16 +18,54 @@ export async function getBookmarkedPractice(problemCount = 10) {
     );
 }
 
+export async function getFolderPracticeCursor(folderId) {
+    if (!folderId) {
+        throw new Error("folderId is required");
+    }
+
+    const response = await apiClient.get(
+        `/api/v1/folders/${folderId}/practice-cursor`
+    );
+
+    const result = response.data.result ?? {};
+
+    return {
+        hasCursor: !!result.hasCursor,
+        nextProblemId: result.nextProblemId ?? null,
+        nextProblemIndex: Number.isFinite(Number(result.nextProblemIndex))
+            ? Number(result.nextProblemIndex)
+            : 0,
+        nextProblemNumber: Number.isFinite(Number(result.nextProblemNumber))
+            ? Number(result.nextProblemNumber)
+            : 1,
+        totalProblemCount: Number.isFinite(Number(result.totalProblemCount))
+            ? Number(result.totalProblemCount)
+            : 0,
+    };
+}
+
 export async function submitProblemSubmission({
                                                   problemId,
                                                   isCorrect,
                                                   elapsedSeconds,
+                                                  practiceMode,
+                                                  folderId,
                                               }) {
-    const response = await apiClient.post("/problem-submissions", {
+    const payload = {
         problemId,
         isCorrect,
         elapsedSeconds,
-    });
+    };
+
+    if (practiceMode) {
+        payload.practiceMode = practiceMode;
+    }
+
+    if (folderId) {
+        payload.folderId = folderId;
+    }
+
+    const response = await apiClient.post("/api/v1/problem-submissions", payload);
 
     return response.data.result;
 }


### PR DESCRIPTION
## 📝 작업 내용 설명

현재 폴더별 문제풀이에서는 사용자가 특정 폴더의 문제를 어디까지 풀었는지 기억하지 못해, 매번 1번 문제부터 다시 시작해야 하는 불편함이 있었다.

이번 작업에서는 폴더 문제풀이에 한해 폴더별 진행 커서를 저장하고, 사용자가 다시 해당 폴더에 진입했을 때 이어서 풀지 처음부터 풀지 선택할 수 있도록 개선했다.

또한 북마크 문제 전체 순회는 별도의 반복 학습 흐름이므로, 폴더별 진행 커서와 분리하여 서로 영향을 주지 않도록 처리했다.

## ✅ 작업 내용

* [x] 폴더별 문제풀이 진행 커서 저장 구조 추가
* [x] 폴더 문제풀이 진입 시 진행 커서 조회 API 구현
* [x] 폴더 문제풀이 진입 시 “이어서 풀까요?” 확인 알림창 표시
* [x] 이어풀기 선택 시 저장된 커서 위치부터 문제풀이 시작
* [x] 처음부터 선택 시 1번 문제부터 문제풀이 시작
* [x] 폴더별 문제 제출 시 다음 문제를 가리키도록 커서 업데이트
* [x] 문제풀이 모드에 `practiceMode`를 추가하여 폴더 문제풀이와 북마크 순회 분리
* [x] 북마크 문제 전체 순회에서는 폴더 커서가 업데이트되지 않도록 분기 처리
* [x] 문제풀이 하단 버튼을 `< 이전`, `다음 >`, `제출 후 다음` 형태로 정리
* [x] 개발/운영 CORS 설정을 프로필별 설정 파일로 분리

## 🔍 주요 변경 포인트

* `FolderPracticeCursor`를 추가하여 폴더별 문제풀이 진행 위치를 별도로 저장하도록 했다.
* 폴더별 문제풀이와 북마크 문제 전체 순회의 진행 상태를 `practiceMode` 기준으로 분리했다.
* 폴더 문제풀이에서 `제출 후 다음`을 누른 경우에만 폴더 커서가 갱신되도록 했다.
* `다음 >` 버튼은 제출 없이 다음 문제로 이동하는 동작으로 분리해 버튼 의미를 명확히 했다.
* 폴더 재진입 시 저장된 커서가 있으면 이어풀기 여부를 선택할 수 있도록 UX를 개선했다.
* 로컬 테스트용 CORS origin은 `application-local.yml`, 운영 CORS origin은 `application-prod.yml`에서 관리하도록 분리했다.

## 🧪 확인한 내용

* [x] 처음 푸는 폴더에서는 1번 문제부터 시작되는지 확인
* [x] 진행 기록이 있는 폴더 클릭 시 이어풀기 알림창이 표시되는지 확인
* [x] 이어풀기 선택 시 저장된 포인터 위치부터 문제가 표시되는지 확인
* [x] 처음부터 선택 시 1번 문제부터 표시되는지 확인
* [x] `제출 후 다음` 클릭 시 문제 제출 API가 호출되는지 확인
* [x] `제출 후 다음` 클릭 시 폴더별 커서가 정상 업데이트되는지 확인
* [x] `다음 >` 클릭 시 제출 없이 다음 문제로 이동하는지 확인
* [x] 북마크 문제 전체 순회에서는 폴더 커서가 업데이트되지 않는지 확인
* [x] 마지막 문제 제출 이후 커서가 다음 시작 위치로 정상 갱신되는지 확인
* [x] 로컬 모바일 접속 환경에서 CORS 설정이 정상 동작하는지 확인

## 📌 비고

* 폴더별 문제풀이 커서는 폴더 문제풀이 전용 진행 상태이다.
* 북마크 문제 전체 순회는 별도의 반복 학습 흐름이므로 이번 커서 업데이트 대상에서 제외했다.
* `다음 >` 버튼은 제출하지 않고 이동하는 버튼이며, `제출 후 다음` 버튼을 눌러야 문제 제출 기록과 폴더 커서가 갱신된다.
* 로컬 개발용 CORS origin은 개인 환경 설정이므로 운영 설정과 분리했다.

## 🔗 관련 이슈

closes #69
