### PR TITLE
feat(home): 폴더 문제 전체 복사 기능 추가

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/repository/FolderRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/folder/repository/FolderRepository.java
@@ -34,4 +34,5 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
             """)
     Integer findMaxSortOrderByParentFolderId(@Param("parentFolderId") Long parentFolderId);
 
+    List<Folder> findAllByParentFolder_FolderId(Long parentFolderId);
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/ProblemRestController.java
@@ -4,12 +4,15 @@ import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
 import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeRequest;
 import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemCopyResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportRequest;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.service.ProblemCommandService;
+import com.hhd1337.jatuli_quiz.domain.problem.service.ProblemQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProblemRestController {
 
     private final ProblemCommandService problemCommandService;
+    private final ProblemQueryService problemQueryService;
 
     @Operation(
             summary = "문제 북마크 토글",
@@ -99,5 +103,24 @@ public class ProblemRestController {
             @Valid @RequestBody PracticeRequest.GetBookmarkedPracticeProblemsRequest request
     ) {
         return ApiResponse.onSuccess(problemCommandService.getBookmarkedPracticeProblems(request));
+    }
+
+    @Operation(
+            summary = "폴더 문제 전체 복사용 조회",
+            description = """
+                    특정 폴더에 포함된 문제 목록을 복사용으로 조회합니다.
+                    
+                    사용자가 홈 화면 문제집 관리 모드에서 '문제 전체 복사'를 누를 때 사용합니다.
+                    선택한 폴더와 그 하위 폴더에 포함된 문제들을 함께 조회합니다.
+                    
+                    이 API는 클립보드 복사용 데이터를 제공하는 read-only 조회 API입니다.
+                    문제 풀이 기록, solvedCount, 북마크 순회 상태, 폴더별 진행 포인터는 변경하지 않습니다.
+                    """
+    )
+    @GetMapping("/folders/{folderId}/copy")
+    public ApiResponse<ProblemCopyResponse.CopyProblemsResponse> getProblemsForCopy(
+            @PathVariable Long folderId
+    ) {
+        return ApiResponse.onSuccess(problemQueryService.getProblemsForCopy(folderId));
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/converter/ProblemConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/converter/ProblemConverter.java
@@ -3,6 +3,7 @@ package com.hhd1337.jatuli_quiz.domain.problem.converter;
 import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
 import com.hhd1337.jatuli_quiz.domain.practice.dto.PracticeResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemBookmarkResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemCopyResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemImportResponse;
 import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
 import java.util.List;
@@ -74,6 +75,31 @@ public class ProblemConverter {
                 .problems(problems.stream()
                         .map(ProblemConverter::toBookmarkedPracticeProblemItem)
                         .toList())
+                .build();
+    }
+
+    public static ProblemCopyResponse.CopyProblemsResponse toCopyProblemsResponse(
+            Long folderId,
+            List<Problem> problems
+    ) {
+        List<ProblemCopyResponse.CopyProblemItem> problemItems = problems.stream()
+                .map(ProblemConverter::toCopyProblemItem)
+                .toList();
+
+        return ProblemCopyResponse.CopyProblemsResponse.builder()
+                .folderId(folderId)
+                .totalCount(problemItems.size())
+                .problems(problemItems)
+                .build();
+    }
+
+    private static ProblemCopyResponse.CopyProblemItem toCopyProblemItem(Problem problem) {
+        return ProblemCopyResponse.CopyProblemItem.builder()
+                .problemId(problem.getProblemId())
+                .problemNum(problem.getProblemNum())
+                .questionText(problem.getQuestionText())
+                .explanationText(problem.getExplanationText())
+                .answerText(problem.getAnswerText())
                 .build();
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ProblemCopyResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/dto/ProblemCopyResponse.java
@@ -1,0 +1,29 @@
+package com.hhd1337.jatuli_quiz.domain.problem.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ProblemCopyResponse {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CopyProblemsResponse {
+        private Long folderId;
+        private Integer totalCount;
+        private List<CopyProblemItem> problems;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class CopyProblemItem {
+        private Long problemId;
+        private Integer problemNum;
+        private String questionText;
+        private String explanationText;
+        private String answerText;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
@@ -115,4 +115,13 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
     boolean existsByFolder(Folder folder);
 
     List<Problem> findByFolder_FolderIdOrderByProblemIdAsc(Long folderId);
+
+    @Query("""
+            select p
+            from Problem p
+            join fetch p.folder f
+            where f.folderId in :folderIds
+            order by f.folderId asc, p.problemNum asc, p.problemId asc
+            """)
+    List<Problem> findAllByFolderIdsForCopy(@Param("folderIds") List<Long> folderIds);
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemQueryService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemQueryService.java
@@ -1,0 +1,8 @@
+package com.hhd1337.jatuli_quiz.domain.problem.service;
+
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemCopyResponse;
+
+public interface ProblemQueryService {
+
+    ProblemCopyResponse.CopyProblemsResponse getProblemsForCopy(Long folderId);
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemQueryServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/service/ProblemQueryServiceImpl.java
@@ -1,0 +1,47 @@
+package com.hhd1337.jatuli_quiz.domain.problem.service;
+
+import com.hhd1337.jatuli_quiz.common.exception.GeneralException;
+import com.hhd1337.jatuli_quiz.common.exception.code.status.ErrorStatus;
+import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
+import com.hhd1337.jatuli_quiz.domain.folder.repository.FolderRepository;
+import com.hhd1337.jatuli_quiz.domain.problem.converter.ProblemConverter;
+import com.hhd1337.jatuli_quiz.domain.problem.dto.ProblemCopyResponse;
+import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemQueryServiceImpl implements ProblemQueryService {
+
+    private final ProblemRepository problemRepository;
+    private final FolderRepository folderRepository;
+
+    @Override
+    public ProblemCopyResponse.CopyProblemsResponse getProblemsForCopy(Long folderId) {
+        Folder folder = folderRepository.findById(folderId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.FOLDER_NOT_FOUND));
+
+        List<Long> folderIds = new ArrayList<>();
+        collectFolderIds(folder.getFolderId(), folderIds);
+
+        List<Problem> problems = problemRepository.findAllByFolderIdsForCopy(folderIds);
+
+        return ProblemConverter.toCopyProblemsResponse(folder.getFolderId(), problems);
+    }
+
+    private void collectFolderIds(Long folderId, List<Long> folderIds) {
+        folderIds.add(folderId);
+
+        List<Folder> childFolders = folderRepository.findAllByParentFolder_FolderId(folderId);
+
+        for (Folder childFolder : childFolders) {
+            collectFolderIds(childFolder.getFolderId(), folderIds);
+        }
+    }
+}

--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -935,14 +935,19 @@ async function copyTextToClipboard(text) {
     textarea.value = text;
     textarea.setAttribute("readonly", "");
     textarea.style.position = "fixed";
-    textarea.style.top = "-9999px";
-    textarea.style.left = "-9999px";
+    textarea.style.top = "0";
+    textarea.style.left = "0";
+    textarea.style.opacity = "0";
+    textarea.style.pointerEvents = "none";
 
     document.body.appendChild(textarea);
+
     textarea.focus();
     textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
 
     const copied = document.execCommand("copy");
+
     document.body.removeChild(textarea);
 
     if (!copied) {
@@ -979,6 +984,9 @@ export default function HomePage() {
 
     const [openedMenuFolderId, setOpenedMenuFolderId] = useState(null);
     const [submitting, setSubmitting] = useState(false);
+
+    const [copyDialog, setCopyDialog] = useState(null);
+    const copyTextareaRef = useRef(null);
 
     function toggleFolder(folderId) {
         setCollapsedFolderIds((prev) => {
@@ -1194,15 +1202,61 @@ export default function HomePage() {
                 problems,
             });
 
-            await copyTextToClipboard(copyText);
+            const isMobileApple =
+                /iPhone|iPad|iPod/i.test(navigator.userAgent);
 
-            alert(`${problems.length}개의 문제가 클립보드에 복사되었습니다.`);
+            if (isMobileApple) {
+                setCopyDialog({
+                    titlePath: result?.folderPath || titlePath,
+                    problemCount: problems.length,
+                    text: copyText,
+                });
+                return;
+            }
+
+            try {
+                await copyTextToClipboard(copyText);
+                alert(`${problems.length}개의 문제가 클립보드에 복사되었습니다.`);
+            } catch (copyError) {
+                console.error("클립보드 복사 실패:", copyError);
+
+                setCopyDialog({
+                    titlePath: result?.folderPath || titlePath,
+                    problemCount: problems.length,
+                    text: copyText,
+                });
+            }
         } catch (err) {
             console.error("문제 전체 복사 실패:", err);
             alert("문제 전체 복사에 실패했습니다.");
         } finally {
             setSubmitting(false);
         }
+    }
+
+    async function handleCopyDialogText() {
+        if (!copyDialog?.text) return;
+
+        try {
+            await copyTextToClipboard(copyDialog.text);
+            alert(`${copyDialog.problemCount}개의 문제가 클립보드에 복사되었습니다.`);
+        } catch (err) {
+            console.error("복사 모달에서 클립보드 복사 실패:", err);
+
+            const textarea = copyTextareaRef.current;
+
+            if (textarea) {
+                textarea.focus();
+                textarea.select();
+                textarea.setSelectionRange(0, textarea.value.length);
+            }
+
+            alert("자동 복사가 막혔습니다. 아래 내용을 직접 길게 눌러 복사해주세요.");
+        }
+    }
+
+    function handleCloseCopyDialog() {
+        setCopyDialog(null);
     }
 
     function handleCancelImportProblems() {
@@ -1833,7 +1887,132 @@ export default function HomePage() {
                     </div>
                 </div>
             )}
+            {copyDialog && (
+                <div
+                    style={{
+                        position: "fixed",
+                        inset: 0,
+                        background: "rgba(0, 0, 0, 0.65)",
+                        zIndex: 200,
+                        display: "flex",
+                        justifyContent: "center",
+                        alignItems: "center",
+                        padding: 16,
+                    }}
+                >
+                    <div
+                        style={{
+                            width: 560,
+                            maxWidth: "100%",
+                            maxHeight: "90vh",
+                            border: "1px solid var(--color-border)",
+                            background: "var(--color-surface)",
+                            color: "var(--color-text)",
+                            borderRadius: 18,
+                            padding: 18,
+                            boxShadow: "0 20px 60px rgba(0, 0, 0, 0.5)",
+                            overflow: "auto",
+                        }}
+                    >
+                        <div
+                            style={{
+                                display: "flex",
+                                justifyContent: "space-between",
+                                alignItems: "flex-start",
+                                gap: 12,
+                                marginBottom: 12,
+                            }}
+                        >
+                            <div>
+                                <h3
+                                    style={{
+                                        margin: 0,
+                                        fontSize: 20,
+                                        letterSpacing: "-0.04em",
+                                    }}
+                                >
+                                    문제 전체 복사
+                                </h3>
 
+                                <p
+                                    style={{
+                                        ...mutedTextStyle,
+                                        marginTop: 6,
+                                        marginBottom: 0,
+                                        fontSize: 13,
+                                        lineHeight: 1.5,
+                                    }}
+                                >
+                                    {copyDialog.titlePath} / {copyDialog.problemCount}문제
+                                </p>
+                            </div>
+
+                            <button
+                                type="button"
+                                onClick={handleCloseCopyDialog}
+                                style={folderIconButtonStyle}
+                            >
+                                ×
+                            </button>
+                        </div>
+
+                        <p
+                            style={{
+                                ...mutedTextStyle,
+                                marginTop: 0,
+                                marginBottom: 10,
+                                fontSize: 13,
+                                lineHeight: 1.6,
+                            }}
+                        >
+                            모바일 브라우저에서 자동 복사가 막힐 수 있습니다.
+                            아래 버튼을 눌러 복사하거나, 안 되면 내용을 직접 길게 눌러 복사해주세요.
+                        </p>
+
+                        <textarea
+                            ref={copyTextareaRef}
+                            value={copyDialog.text}
+                            readOnly
+                            rows={14}
+                            onFocus={(e) => e.target.select()}
+                            style={{
+                                ...textareaStyle,
+                                fontSize: 13,
+                                minHeight: 260,
+                            }}
+                        />
+
+                        <div
+                            style={{
+                                display: "flex",
+                                gap: 8,
+                                marginTop: 14,
+                            }}
+                        >
+                            <button
+                                type="button"
+                                onClick={handleCopyDialogText}
+                                style={{
+                                    ...getButtonStyle(false),
+                                    flex: 1,
+                                    background: "var(--color-primary)",
+                                    color: "var(--color-bg)",
+                                }}
+                            >
+                                클립보드에 복사
+                            </button>
+
+                            <button
+                                type="button"
+                                onClick={handleCloseCopyDialog}
+                                style={getButtonStyle(false)}
+                            >
+                                닫기
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -7,7 +7,10 @@ import {
     deleteFolder,
     reorderChildFolders,
 } from "../../shared/api/folderApi";
-import { importProblemsText } from "../../shared/api/quizApi";
+import {
+    importProblemsText,
+    getFolderProblemsForCopy,
+} from "../../shared/api/quizApi";
 
 const pageStyle = {
     width: "100%",
@@ -419,6 +422,7 @@ function FolderTreeItem({
                             onCancelCreateFolder,
 
                             onStartImportProblems,
+                            onCopyFolderProblems,
 
                             openedMenuFolderId,
                             onToggleFolderMenu,
@@ -593,6 +597,20 @@ function FolderTreeItem({
                                         boxShadow: "0 12px 30px rgba(0, 0, 0, 0.35)",
                                     }}
                                 >
+                                    <button
+                                        type="button"
+                                        onClick={() => onCopyFolderProblems(folder, titlePath)}
+                                        disabled={submitting}
+                                        style={{
+                                            ...folderActionButtonStyle,
+                                            width: "100%",
+                                            borderRadius: 8,
+                                            justifyContent: "center",
+                                            color: "var(--color-primary)",
+                                        }}
+                                    >
+                                        문제 전체 복사
+                                    </button>
                                     {isLeaf && (
                                         <button
                                             type="button"
@@ -768,6 +786,7 @@ function FolderTreeItem({
                             onCancelCreateFolder={onCancelCreateFolder}
 
                             onStartImportProblems={onStartImportProblems}
+                            onCopyFolderProblems={onCopyFolderProblems}
 
                             openedMenuFolderId={openedMenuFolderId}
                             onToggleFolderMenu={onToggleFolderMenu}
@@ -845,6 +864,90 @@ function moveItem(array, fromIndex, toIndex) {
     const [removed] = copied.splice(fromIndex, 1);
     copied.splice(toIndex, 0, removed);
     return copied;
+}
+
+const GPT_COPY_PROMPT = `이 대화창에서는 아래 문제들에 대해 물어볼 것입니다.
+당신은 선생님이라고 생각하고, 제가 질문하는 내용에 대해 자세하고 친절하게 설명해주세요.
+단순히 정답만 말하지 말고, 왜 그런 답이 되는지 개념부터 차근차근 길게 설명해주세요.
+우선 아래 문제를 먼저 학습만 해주세요.`;
+
+function normalizeProblemText(value) {
+    if (value === null || value === undefined) {
+        return "";
+    }
+
+    return String(value).trim();
+}
+
+function buildProblemCopyText({ titlePath, problems }) {
+    const problemBlocks = problems.map((problem, index) => {
+        const question = normalizeProblemText(
+            problem.questionText ??
+            problem.question ??
+            problem.content ??
+            problem.problemText
+        );
+
+        const answer = normalizeProblemText(
+            problem.answerText ??
+            problem.answer ??
+            problem.correctAnswer
+        );
+
+        const explanation = normalizeProblemText(
+            problem.explanationText ??
+            problem.explanation ??
+            problem.commentary ??
+            problem.solution
+        );
+
+        const problemNumber = problem.problemNum ?? index + 1;
+
+        return `## 문제 ${problemNumber}
+
+문제:
+${question || "(문제 내용 없음)"}
+
+정답:
+${answer || "(정답 없음)"}
+
+해설:
+${explanation || "(해설 없음)"}`;
+    });
+
+    return `${GPT_COPY_PROMPT}
+
+# 문제 목록
+
+폴더:
+${titlePath}
+
+${problemBlocks.join("\n\n")}`;
+}
+
+async function copyTextToClipboard(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+        return;
+    }
+
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.top = "-9999px";
+    textarea.style.left = "-9999px";
+
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+
+    const copied = document.execCommand("copy");
+    document.body.removeChild(textarea);
+
+    if (!copied) {
+        throw new Error("클립보드 복사에 실패했습니다.");
+    }
 }
 
 export default function HomePage() {
@@ -1071,6 +1174,35 @@ export default function HomePage() {
 
         setProblemImportText("");
         setOpenedMenuFolderId(null);
+    }
+
+    async function handleCopyFolderProblems(folder, titlePath) {
+        try {
+            setSubmitting(true);
+            setOpenedMenuFolderId(null);
+
+            const result = await getFolderProblemsForCopy(folder.folderId);
+            const problems = Array.isArray(result?.problems) ? result.problems : [];
+
+            if (problems.length === 0) {
+                alert("복사할 문제가 없습니다.");
+                return;
+            }
+
+            const copyText = buildProblemCopyText({
+                titlePath: result?.folderPath || titlePath,
+                problems,
+            });
+
+            await copyTextToClipboard(copyText);
+
+            alert(`${problems.length}개의 문제가 클립보드에 복사되었습니다.`);
+        } catch (err) {
+            console.error("문제 전체 복사 실패:", err);
+            alert("문제 전체 복사에 실패했습니다.");
+        } finally {
+            setSubmitting(false);
+        }
     }
 
     function handleCancelImportProblems() {
@@ -1568,6 +1700,7 @@ export default function HomePage() {
                                     onCancelCreateFolder={handleCancelCreateFolder}
 
                                     onStartImportProblems={handleStartImportProblems}
+                                    onCopyFolderProblems={handleCopyFolderProblems}
 
                                     openedMenuFolderId={openedMenuFolderId}
                                     onToggleFolderMenu={handleToggleFolderMenu}

--- a/frontend/src/shared/api/quizApi.js
+++ b/frontend/src/shared/api/quizApi.js
@@ -114,3 +114,11 @@ export async function toggleProblemBookmark(problemId) {
         isBookmarked: !!result.isBookmarked,
     };
 }
+
+export async function getFolderProblemsForCopy(folderId) {
+    const response = await apiClient.get(
+        `/api/v1/problems/folders/${folderId}/copy`
+    );
+
+    return response.data.result;
+}


### PR DESCRIPTION
## 📝 작업 내용 설명

홈 화면 문제집 영역의 `관리 모드`에서 각 폴더의 `...` 더보기 메뉴 최상단에 `문제 전체 복사` 기능을 추가했습니다.

사용자는 특정 폴더의 `문제 전체 복사`를 클릭하면 해당 폴더와 하위 폴더에 포함된 문제들을 한 번에 조회하고, GPT 대화창에 바로 붙여넣을 수 있는 학습용 프롬프트 형태로 복사할 수 있습니다.

또한 iOS Safari 계열 브라우저에서는 비동기 API 조회 이후 자동 클립보드 복사가 제한될 수 있어, 복사 텍스트를 모달로 제공하고 사용자가 직접 복사할 수 있는 fallback UI를 추가했습니다.

## ✅ 작업 내용

* [x] 폴더 문제 전체 복사용 조회 API 추가
* [x] 선택한 폴더 및 하위 폴더의 문제 목록 조회 처리
* [x] 홈 화면 관리 모드 `...` 메뉴 최상단에 `문제 전체 복사` 버튼 추가
* [x] 문제 번호, 문제 내용, 정답, 해설을 포함한 복사 텍스트 생성
* [x] GPT 학습용 안내 프롬프트를 복사 텍스트 상단에 포함
* [x] 클립보드 복사 성공/실패 안내 처리
* [x] iOS 클립보드 제한 대응을 위한 복사용 모달 및 직접 복사 fallback 추가

## 🔍 주요 변경 포인트

* 기존 홈 화면 문제집 관리 모드의 더보기 메뉴에 `문제 전체 복사` 항목을 추가했습니다.
* 복사 대상은 사용자가 더보기 메뉴를 연 폴더 기준이며, 해당 폴더의 하위 폴더 문제까지 함께 조회합니다.
* 복사 텍스트는 GPT에 바로 붙여넣어 학습 질문을 이어갈 수 있도록 안내 프롬프트와 문제 목록을 함께 구성했습니다.
* 백엔드 API는 read-only 조회 API로 구현하여 문제 풀이 기록, solvedCount, 북마크 순회 상태, 폴더별 진행 포인터에는 영향을 주지 않도록 했습니다.
* 모바일 브라우저의 클립보드 제약을 고려해 자동 복사가 실패하더라도 사용자가 모달에서 직접 복사할 수 있도록 보완했습니다.

## 🧪 확인한 내용

* [x] 로컬 환경에서 홈 화면 정상 조회 확인
* [x] 폴더 문제 전체 복사용 API 요청/응답 확인
* [x] `문제 전체 복사` 클릭 시 선택 폴더 기준 문제 목록 조회 확인
* [x] 복사 텍스트에 GPT용 안내 프롬프트가 포함되는지 확인
* [x] 문제 내용, 정답, 해설이 누락 없이 복사되는지 확인
* [x] PC 브라우저에서 클립보드 복사 성공 확인
* [x] iOS 대응용 복사 모달 표시 및 fallback UI 확인

## 📌 비고

iOS Safari 계열 브라우저에서는 보안 정책상 API 조회 이후 자동 클립보드 복사가 제한될 수 있어, 모바일 환경에서는 복사 텍스트를 모달에 표시하고 사용자가 직접 복사할 수 있도록 처리했습니다.

문제가 없는 폴더의 경우 복사할 문제가 없다는 안내를 표시하도록 처리했습니다.

## 🔗 관련 이슈

closes #70
