### PR TITLE
feat(auth): 단일 관리자 로그인 및 변경 API 보호 적용

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -65,8 +65,11 @@ jobs:
               --name jatuli-backend-container \
               --restart unless-stopped \
               -p 8080:8080 \
+              -e SPRING_PROFILES_ACTIVE='prod' \
               -e DB_URL='${{ secrets.DB_URL }}' \
               -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \
               -e DB_PASSWORD='${{ secrets.DB_PASSWORD }}' \
+              -e JATULI_ADMIN_USERNAME='${{ secrets.JATULI_ADMIN_USERNAME }}' \
+              -e JATULI_ADMIN_PASSWORD_HASH='${{ secrets.JATULI_ADMIN_PASSWORD_HASH }}' \
               ${{ env.IMAGE_NAME }}
             docker image prune -f

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/AdminProperties.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/AdminProperties.java
@@ -1,0 +1,20 @@
+package com.hhd1337.jatuli_quiz.config;
+
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.admin")
+public record AdminProperties(
+        String username,
+        String passwordHash
+) {
+    public AdminProperties {
+        if (username == null || username.isBlank()) {
+            throw new IllegalArgumentException("app.admin.username must not be blank");
+        }
+
+        if (passwordHash == null || passwordHash.isBlank()) {
+            throw new IllegalArgumentException("app.admin.password-hash must not be blank");
+        }
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/CorsProperties.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/CorsProperties.java
@@ -1,0 +1,15 @@
+package com.hhd1337.jatuli_quiz.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(
+        List<String> allowedOrigins
+) {
+    public CorsProperties {
+        if (allowedOrigins == null || allowedOrigins.isEmpty()) {
+            throw new IllegalArgumentException("app.cors.allowed-origins must not be empty");
+        }
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/SecurityConfig.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/SecurityConfig.java
@@ -1,0 +1,222 @@
+package com.hhd1337.jatuli_quiz.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableConfigurationProperties({
+        AdminProperties.class,
+        CorsProperties.class
+})
+public class SecurityConfig {
+
+    private final AdminProperties adminProperties;
+    private final CorsProperties corsProperties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return new InMemoryUserDetailsManager(
+                User.withUsername(adminProperties.username())
+                        .password(adminProperties.passwordHash())
+                        .roles("ADMIN")
+                        .build()
+        );
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+
+                        // 조회성 POST API는 데이터 변경이 아니므로 CSRF 검사에서 제외
+                        .ignoringRequestMatchers(
+                                "/practice/random",
+                                "/practice/bookmarks",
+                                "/api/v1/problems/bookmarked/practice"
+                        )
+                )
+
+                .authorizeHttpRequests(auth -> auth
+                        // 인증 관련 API
+                        .requestMatchers(HttpMethod.GET, "/api/auth/csrf").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/auth/me").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
+
+                        // 헬스 체크
+                        .requestMatchers(HttpMethod.GET, "/health").permitAll()
+
+                        // Swagger는 일단 허용. 운영에서 막고 싶으면 authenticated()로 변경
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+
+                        // 조회 API 허용
+                        .requestMatchers(HttpMethod.GET, "/**").permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
+                        // 조회성 POST API 허용
+                        .requestMatchers(HttpMethod.POST, "/practice/random").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/practice/bookmarks").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/problems/bookmarked/practice").permitAll()
+
+                        // 문제 데이터 변경 API 보호
+                        .requestMatchers(HttpMethod.POST, "/api/v1/problems").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/problems/*/bookmark").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/problems/import/text").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/problems/**").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/problems/**").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/problems/**").authenticated()
+
+                        // 문제 제출 결과 저장 API 보호
+                        .requestMatchers(HttpMethod.POST, "/api/v1/problem-submissions").authenticated()
+
+                        // 폴더 데이터 변경 API 보호
+                        .requestMatchers(HttpMethod.POST, "/api/v1/folders").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/folders/*/practice-cursor").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/folders/**").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/folders/**").authenticated()
+
+                        // 나머지는 일단 허용
+                        .anyRequest().permitAll()
+                )
+
+                .formLogin(form -> form
+                        .loginProcessingUrl("/api/auth/login")
+                        .usernameParameter("username")
+                        .passwordParameter("password")
+                        .successHandler((request, response, authentication) -> writeJson(
+                                response,
+                                HttpServletResponse.SC_OK,
+                                successBody(
+                                        "AUTH200",
+                                        "로그인에 성공했습니다.",
+                                        Map.of(
+                                                "username", authentication.getName()
+                                        )
+                                )
+                        ))
+                        .failureHandler((request, response, exception) -> writeJson(
+                                response,
+                                HttpServletResponse.SC_UNAUTHORIZED,
+                                failBody(
+                                        "AUTH401",
+                                        "아이디 또는 비밀번호가 올바르지 않습니다."
+                                )
+                        ))
+                )
+
+                .logout(logout -> logout
+                        .logoutUrl("/api/auth/logout")
+                        .logoutSuccessHandler((request, response, authentication) -> writeJson(
+                                response,
+                                HttpServletResponse.SC_OK,
+                                successBody(
+                                        "AUTH200",
+                                        "로그아웃되었습니다.",
+                                        null
+                                )
+                        ))
+                )
+
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> writeJson(
+                                response,
+                                HttpServletResponse.SC_UNAUTHORIZED,
+                                failBody(
+                                        "AUTH401",
+                                        "로그인이 필요합니다."
+                                )
+                        ))
+                        .accessDeniedHandler((request, response, accessDeniedException) -> writeJson(
+                                response,
+                                HttpServletResponse.SC_FORBIDDEN,
+                                failBody(
+                                        "AUTH403",
+                                        "접근 권한이 없습니다."
+                                )
+                        ))
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        return request -> {
+            CorsConfiguration config = new CorsConfiguration();
+
+            config.setAllowedOrigins(corsProperties.allowedOrigins());
+            config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+            config.setAllowedHeaders(List.of("*"));
+            config.setAllowCredentials(true);
+
+            return config;
+        };
+    }
+
+    private void writeJson(
+            HttpServletResponse response,
+            int status,
+            Map<String, Object> body
+    ) throws IOException {
+        response.setStatus(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+
+    private Map<String, Object> successBody(
+            String code,
+            String message,
+            Object result
+    ) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("isSuccess", true);
+        body.put("code", code);
+        body.put("message", message);
+        body.put("result", result);
+        return body;
+    }
+
+    private Map<String, Object> failBody(
+            String code,
+            String message
+    ) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("isSuccess", false);
+        body.put("code", code);
+        body.put("message", message);
+        body.put("result", null);
+        return body;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/WebConfig.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/WebConfig.java
@@ -1,28 +1,18 @@
 package com.hhd1337.jatuli_quiz.config;
 
-import java.util.Arrays;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-
-    @Value("${app.cors.allowed-origins}")
-    private String allowedOrigins;
-
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        String[] origins = Arrays.stream(allowedOrigins.split(","))
-                .map(String::trim)
-                .filter(origin -> !origin.isBlank())
-                .toArray(String[]::new);
-
-        registry.addMapping("/**")
-                .allowedOrigins(origins)
-                .allowedMethods("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(false);
-    }
+    /*
+     * CORS 설정은 SecurityConfig에서 처리한다.
+     *
+     * 이유:
+     * - 이번 작업은 Spring Security 기반 세션 로그인을 사용한다.
+     * - 세션 쿠키(JSESSIONID)를 프론트엔드와 백엔드 간에 주고받아야 한다.
+     * - 따라서 CORS도 Spring Security 필터 체인에서 함께 처리하는 편이 명확하다.
+     *
+     * 기존 WebConfig의 allowCredentials(false)는 세션 쿠키 전달을 방해할 수 있으므로 제거한다.
+     */
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/auth/controller/AuthController.java
@@ -1,0 +1,51 @@
+package com.hhd1337.jatuli_quiz.domain.auth.controller;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    @GetMapping("/api/auth/csrf")
+    public Map<String, Object> csrf(CsrfToken csrfToken) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("token", csrfToken.getToken());
+        result.put("headerName", csrfToken.getHeaderName());
+        result.put("parameterName", csrfToken.getParameterName());
+
+        return success("AUTH200", "CSRF 토큰 조회에 성공했습니다.", result);
+    }
+
+    @GetMapping("/api/auth/me")
+    public Map<String, Object> me(Authentication authentication) {
+        boolean authenticated = authentication != null
+                && authentication.isAuthenticated()
+                && !"anonymousUser".equals(authentication.getPrincipal());
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("authenticated", authenticated);
+
+        if (authenticated) {
+            result.put("username", authentication.getName());
+        }
+
+        return success("AUTH200", "인증 상태 조회에 성공했습니다.", result);
+    }
+
+    private Map<String, Object> success(
+            String code,
+            String message,
+            Object result
+    ) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("isSuccess", true);
+        body.put("code", code);
+        body.put("message", message);
+        body.put("result", result);
+        return body;
+    }
+}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -13,10 +13,22 @@ spring:
       hibernate:
         format_sql: false
 
+server:
+  servlet:
+    session:
+      cookie:
+        http-only: true
+        secure: true
+        same-site: lax
+
 app:
+  admin:
+    username: ${JATULI_ADMIN_USERNAME}
+    password-hash: ${JATULI_ADMIN_PASSWORD_HASH}
+
   cors:
-    allowed-origins: >
-      https://jatuli.online,
-      https://www.jatuli.online,
-      https://jatuli-quiz-frontend.vercel.app,
-      https://api.jatuli.online
+    allowed-origins:
+      - https://jatuli.online
+      - https://www.jatuli.online
+      - https://jatuli-quiz-frontend.vercel.app
+      - https://api.jatuli.online

--- a/frontend/src/app/router.jsx
+++ b/frontend/src/app/router.jsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from "react-router-dom";
 import AppShell from "./AppShell";
+import LoginPage from "../pages/auth/LoginPage";
 
 import HomePage from "../pages/home/HomePage";
 import QuizPlayPage from "../pages/quiz/QuizPlayPage";
@@ -15,6 +16,7 @@ export const router = createBrowserRouter([
       { path: "/quiz/play", element: <QuizPlayPage /> },
       { path: "/quiz/:quizId/edit", element: <QuizEditPage /> },
       { path: "/test/health", element: <HealthCheckPage /> },
+      { path: "/login", element: <LoginPage /> },
       { path: "*", element: <NotFoundPage /> },
     ],
   },

--- a/frontend/src/pages/auth/LoginPage.css
+++ b/frontend/src/pages/auth/LoginPage.css
@@ -1,0 +1,81 @@
+.login-page {
+    min-height: 100vh;
+    padding: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-bg);
+    color: var(--color-text);
+}
+
+.login-card {
+    width: 100%;
+    max-width: 360px;
+    padding: 24px;
+    border: 1px solid var(--color-border);
+    border-radius: 18px;
+    background: var(--color-surface);
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.login-title {
+    margin: 0 0 4px;
+    text-align: center;
+    font-size: 24px;
+    line-height: 1.3;
+}
+
+.login-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    color: var(--color-text-muted);
+    font-size: 14px;
+}
+
+.login-field input {
+    width: 100%;
+    min-height: 46px;
+    padding: 12px 14px;
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    background: var(--color-surface-soft);
+    color: var(--color-text);
+    font-size: 16px;
+}
+
+.login-field input::placeholder {
+    color: var(--color-text-muted);
+}
+
+.login-field input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+}
+
+.login-error {
+    margin: 0;
+    color: #fca5a5;
+    font-size: 14px;
+    text-align: center;
+}
+
+.login-button {
+    width: 100%;
+    min-height: 46px;
+    padding: 12px 14px;
+    border: none;
+    border-radius: 12px;
+    background: var(--color-primary);
+    color: #111827;
+    font-weight: 700;
+    font-size: 16px;
+    cursor: pointer;
+}
+
+.login-button:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+}

--- a/frontend/src/pages/auth/LoginPage.jsx
+++ b/frontend/src/pages/auth/LoginPage.jsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { login } from "../../shared/api/authApi";
+import "./LoginPage.css";
+
+export default function LoginPage() {
+    const navigate = useNavigate();
+
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [errorMessage, setErrorMessage] = useState("");
+
+    async function handleSubmit(event) {
+        event.preventDefault();
+
+        if (isSubmitting) {
+            return;
+        }
+
+        setIsSubmitting(true);
+        setErrorMessage("");
+
+        try {
+            await login({
+                username,
+                password,
+            });
+
+            navigate("/");
+        } catch (error) {
+            setErrorMessage("아이디 또는 비밀번호가 올바르지 않습니다.");
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    return (
+        <main className="login-page">
+            <form className="login-card" onSubmit={handleSubmit}>
+                <h1 className="login-title">관리자 로그인</h1>
+
+                <label className="login-field">
+                    <span>아이디</span>
+                    <input
+                        type="text"
+                        name="username"
+                        value={username}
+                        autoComplete="username"
+                        placeholder="아이디를 입력하세요"
+                        onChange={(event) => setUsername(event.target.value)}
+                    />
+                </label>
+
+                <label className="login-field">
+                    <span>비밀번호</span>
+                    <input
+                        type="password"
+                        name="password"
+                        value={password}
+                        autoComplete="current-password"
+                        placeholder="비밀번호를 입력하세요"
+                        onChange={(event) => setPassword(event.target.value)}
+                    />
+                </label>
+
+                {errorMessage && (
+                    <p className="login-error">{errorMessage}</p>
+                )}
+
+                <button
+                    className="login-button"
+                    type="submit"
+                    disabled={isSubmitting}
+                >
+                    {isSubmitting ? "로그인 중..." : "로그인"}
+                </button>
+            </form>
+        </main>
+    );
+}

--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getHomeData } from "../../shared/api/homeApi";
+import { getAuthStatus, logout } from "../../shared/api/authApi";
+
 import {
     createFolder,
     renameFolder,
@@ -57,6 +59,18 @@ const buttonBaseStyle = {
     borderRadius: 10,
     fontWeight: 700,
     fontSize: 15,
+};
+
+const authButtonStyle = {
+    border: "1px solid var(--color-border)",
+    background: "var(--color-button-bg)",
+    color: "var(--color-button-text)",
+    borderRadius: 999,
+    padding: "7px 12px",
+    fontSize: 13,
+    fontWeight: 800,
+    cursor: "pointer",
+    whiteSpace: "nowrap",
 };
 
 const folderActionButtonStyle = {
@@ -962,6 +976,9 @@ export default function HomePage() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
 
+    const [authLoading, setAuthLoading] = useState(true);
+    const [isAuthenticated, setIsAuthenticated] = useState(false);
+
     const [initialCollapsedFolderIds] = useState(() =>
         readCollapsedFolderIdsFromStorage()
     );
@@ -1325,8 +1342,48 @@ export default function HomePage() {
         }
     }
 
+    async function fetchAuthStatus() {
+        try {
+            setAuthLoading(true);
+
+            const result = await getAuthStatus();
+
+            setIsAuthenticated(Boolean(result?.authenticated));
+        } catch (err) {
+            console.error("인증 상태 조회 실패:", err);
+            setIsAuthenticated(false);
+        } finally {
+            setAuthLoading(false);
+        }
+    }
+
+    function handleGoLogin() {
+        navigate("/login");
+    }
+
+    async function handleLogout() {
+        const confirmed = window.confirm("로그아웃할까요?");
+
+        if (!confirmed) {
+            return;
+        }
+
+        try {
+            await logout();
+
+            setIsAuthenticated(false);
+            setIsManageMode(false);
+
+            alert("로그아웃되었습니다.");
+        } catch (err) {
+            console.error("로그아웃 실패:", err);
+            alert("로그아웃에 실패했습니다.");
+        }
+    }
+
     useEffect(() => {
         fetchHomeData();
+        fetchAuthStatus();
     }, []);
 
     if (loading) {
@@ -1389,12 +1446,16 @@ export default function HomePage() {
                     style={{
                         display: "flex",
                         justifyContent: "space-between",
-                        alignItems: "flex-end",
+                        alignItems: "flex-start",
                         gap: 16,
                         marginBottom: 7,
                     }}
                 >
-                    <div>
+                    <div
+                        style={{
+                            minWidth: 0,
+                        }}
+                    >
                         <h1
                             style={{
                                 margin: 0,
@@ -1424,6 +1485,27 @@ export default function HomePage() {
                             <li>자신을 믿지 못하는 녀석은 노력할 가치도 없다. 나는 나를 믿는다.</li>
                         </ol>
                     </div>
+
+                    <button
+                        type="button"
+                        onClick={isAuthenticated ? handleLogout : handleGoLogin}
+                        disabled={authLoading}
+                        style={{
+                            ...authButtonStyle,
+                            marginTop: 1,
+                            opacity: authLoading ? 0.6 : 1,
+                            cursor: authLoading ? "not-allowed" : "pointer",
+                            background: isAuthenticated
+                                ? "var(--color-primary)"
+                                : "var(--color-button-bg)",
+                            color: isAuthenticated
+                                ? "var(--color-bg)"
+                                : "var(--color-button-text)",
+                        }}
+                        aria-label={isAuthenticated ? "로그아웃" : "로그인"}
+                    >
+                        {authLoading ? "확인 중" : isAuthenticated ? "로그아웃" : "로그인"}
+                    </button>
                 </div>
             </header>
 
@@ -1696,24 +1778,39 @@ export default function HomePage() {
                                 </h2>
                             </div>
 
-                            <button
-                                type="button"
-                                onClick={() => setIsManageMode((prev) => !prev)}
-                                style={{
-                                    ...getButtonStyle(false),
-                                    padding: "7px 12px",
-                                    marginBottom: 10,
-                                    fontSize: 13,
-                                    background: isManageMode
-                                        ? "var(--color-primary)"
-                                        : "var(--color-button-bg)",
-                                    color: isManageMode
-                                        ? "var(--color-bg)"
-                                        : "var(--color-button-text)",
-                                }}
-                            >
-                                {isManageMode ? "관리 모드 끄기" : "관리 모드"}
-                            </button>
+                            {isAuthenticated ? (
+                                <button
+                                    type="button"
+                                    onClick={() => setIsManageMode((prev) => !prev)}
+                                    style={{
+                                        ...getButtonStyle(false),
+                                        padding: "7px 12px",
+                                        marginBottom: 10,
+                                        fontSize: 13,
+                                        background: isManageMode
+                                            ? "var(--color-primary)"
+                                            : "var(--color-button-bg)",
+                                        color: isManageMode
+                                            ? "var(--color-bg)"
+                                            : "var(--color-button-text)",
+                                    }}
+                                >
+                                    {isManageMode ? "관리 모드 끄기" : "관리 모드"}
+                                </button>
+                            ) : (
+                                <button
+                                    type="button"
+                                    onClick={handleGoLogin}
+                                    style={{
+                                        ...getButtonStyle(false),
+                                        padding: "7px 12px",
+                                        marginBottom: 10,
+                                        fontSize: 13,
+                                    }}
+                                >
+                                    관리 로그인
+                                </button>
+                            )}
                         </div>
 
                         {rootFolders.map((folder, index) => (

--- a/frontend/src/shared/api/authApi.js
+++ b/frontend/src/shared/api/authApi.js
@@ -1,0 +1,34 @@
+import { apiClient, refreshCsrfToken } from "./client";
+
+export async function login({ username, password }) {
+    await refreshCsrfToken();
+
+    const formData = new URLSearchParams();
+    formData.append("username", username);
+    formData.append("password", password);
+
+    const response = await apiClient.post("/api/auth/login", formData, {
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+    });
+
+    // 로그인 성공 후 Spring Security가 CSRF 토큰을 새로 만들 수 있으므로 다시 갱신한다.
+    await refreshCsrfToken();
+
+    return response.data.result;
+}
+
+export async function logout() {
+    await refreshCsrfToken();
+
+    const response = await apiClient.post("/api/auth/logout");
+
+    return response.data.result;
+}
+
+export async function getAuthStatus() {
+    const response = await apiClient.get("/api/auth/me");
+
+    return response.data.result;
+}

--- a/frontend/src/shared/api/client.js
+++ b/frontend/src/shared/api/client.js
@@ -6,10 +6,78 @@ if (!baseURL) {
     console.warn("VITE_API_BASE_URL이 설정되지 않았습니다.");
 }
 
+const unsafeMethods = new Set(["post", "put", "patch", "delete"]);
+
+let cachedCsrfToken = null;
+
+const csrfClient = axios.create({
+    baseURL,
+    timeout: 5000,
+    withCredentials: true,
+});
+
+async function fetchCsrfToken() {
+    const response = await csrfClient.get("/api/auth/csrf");
+
+    const result = response.data?.result ?? response.data;
+
+    cachedCsrfToken = result?.token ?? null;
+
+    return cachedCsrfToken;
+}
+
+export async function refreshCsrfToken() {
+    cachedCsrfToken = null;
+    return fetchCsrfToken();
+}
+
+export function clearCsrfToken() {
+    cachedCsrfToken = null;
+}
+
 export const apiClient = axios.create({
     baseURL,
     timeout: 5000,
+    withCredentials: true,
     headers: {
         "Content-Type": "application/json",
     },
 });
+
+apiClient.interceptors.request.use(async (config) => {
+    const method = config.method?.toLowerCase();
+
+    if (!unsafeMethods.has(method)) {
+        return config;
+    }
+
+    if (!cachedCsrfToken) {
+        await fetchCsrfToken();
+    }
+
+    config.headers = config.headers ?? {};
+    config.headers["X-XSRF-TOKEN"] = cachedCsrfToken;
+
+    return config;
+});
+
+apiClient.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+        const status = error.response?.status;
+
+        if (status === 403) {
+            clearCsrfToken();
+        }
+
+        if (status === 401 || status === 403) {
+            const currentPath = window.location.pathname;
+
+            if (currentPath !== "/login") {
+                window.location.href = "/login";
+            }
+        }
+
+        return Promise.reject(error);
+    }
+);


### PR DESCRIPTION
## 📝 작업 내용 설명

현재 서비스는 개인용 학습 서비스이지만 웹으로 배포되어 있어, URL 또는 API 경로를 아는 사용자가 문제/폴더 데이터를 임의로 변경할 가능성이 있었습니다.

이번 PR에서는 복잡한 회원가입/권한 체계 대신 개인용 MVP에 맞는 단일 관리자 로그인 방식을 적용했습니다.

Spring Security 기반 세션 로그인을 도입하고, 로그인한 사용자만 문제/폴더 생성·수정·삭제 및 문제 일괄 업로드 등 데이터 변경 기능을 사용할 수 있도록 백엔드에서 변경 API 접근을 차단했습니다.

프론트엔드에는 관리자 로그인 화면을 추가하고, 로그인 상태에 따라 홈 화면에서 로그인/로그아웃 및 관리 모드 진입 UI가 동작하도록 연동했습니다.

## ✅ 작업 내용

- [x] Spring Security 의존성 추가
- [x] 단일 관리자 계정 설정 추가
- [x] 환경변수 기반 관리자 아이디/비밀번호 해시 설정 적용
- [x] BCrypt 기반 비밀번호 검증 적용
- [x] 세션 기반 로그인/로그아웃 API 설정
- [x] CSRF 토큰 발급 및 검증 흐름 추가
- [x] 인증되지 않은 사용자의 데이터 변경 API 접근 차단
- [x] 문제 북마크 토글 API 보호
- [x] 문제 제출 결과 저장 API 보호
- [x] 문제 일괄 업로드 API 보호
- [x] 폴더 생성/이름변경/삭제/순서변경 API 보호
- [x] 관리자 로그인 페이지 추가
- [x] 프론트 API 클라이언트에 세션 쿠키 및 CSRF 헤더 자동 연동
- [x] 홈 화면 우측 상단 로그인/로그아웃 버튼 추가
- [x] 로그인 상태에 따라 관리 모드 버튼 노출 처리

## 🔍 주요 변경 포인트

- 개인용 MVP 특성에 맞게 다중 사용자 회원가입이나 역할 기반 권한 체계는 도입하지 않았습니다.
- 로그인한 사용자를 서비스 관리자처럼 취급하는 단일 관리자 인증 구조로 구현했습니다.
- 프론트엔드 버튼 숨김이 아니라, 백엔드 Spring Security 설정을 통해 변경 API 접근을 강제 차단했습니다.
- 조회성 API는 기존처럼 비로그인 상태에서도 사용할 수 있도록 유지했습니다.
- 세션 기반 인증을 사용하며, 프론트에서는 `withCredentials`와 CSRF 토큰 헤더를 자동으로 처리하도록 구성했습니다.
- 아이폰 Safari/iCloud Keychain 자동완성을 고려해 일반 아이디/비밀번호 로그인 폼을 추가했습니다.

## 🧪 확인한 내용

- [x] 로컬 환경에서 정상 동작 확인
- [x] 비로그인 상태에서 폴더 생성/수정/삭제 API 차단 확인
- [x] 비로그인 상태에서 폴더 순서 변경 API 차단 확인
- [x] 비로그인 상태에서 문제 일괄 업로드 API 차단 확인
- [x] 비로그인 상태에서 문제 북마크 토글 API 차단 확인
- [x] 로그인 후 관리 모드 진입 확인
- [x] 로그인 후 폴더 순서 변경 정상 동작 확인
- [x] 로그인 후 보호 API 호출 시 CSRF 토큰이 정상 포함되는지 확인
- [x] 로그아웃 후 보호 API 접근이 다시 차단되는지 확인
- [x] 기존 홈 화면 조회 및 문제 조회 기능 정상 동작 확인

## 📌 비고

- 이번 PR에서는 다중 사용자 회원가입, USER/ADMIN 역할 분리, OAuth 로그인, JWT refresh token 구조는 도입하지 않았습니다.
- 개인용 MVP 단계이므로 “로그인한 사용자 = 서비스 관리자”로 간주합니다.
- 운영 환경의 관리자 아이디와 비밀번호 해시는 GitHub Actions Secret 또는 서버 환경변수로 주입해야 합니다.
- 운영 환경 Swagger 접근 제한은 필요 시 별도 이슈에서 `authenticated()` 처리 또는 비활성화 방식으로 진행할 수 있습니다.

## 🔗 관련 이슈

closes #71