### PR TITLE
fix(backend/auth): 운영 환경 CSRF 쿠키 SameSite 설정 수정

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/SecurityConfig.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/SecurityConfig.java
@@ -5,13 +5,16 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.User;
@@ -35,7 +38,14 @@ public class SecurityConfig {
 
     private final AdminProperties adminProperties;
     private final CorsProperties corsProperties;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${server.servlet.session.cookie.secure:false}")
+    private boolean cookieSecure;
+
+    @Value("${server.servlet.session.cookie.same-site:lax}")
+    private String cookieSameSite;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -53,15 +63,31 @@ public class SecurityConfig {
     }
 
     @Bean
+    public CookieCsrfTokenRepository csrfTokenRepository() {
+        CookieCsrfTokenRepository repository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+
+        repository.setCookieCustomizer((ResponseCookie.ResponseCookieBuilder builder) ->
+                builder
+                        .secure(cookieSecure)
+                        .sameSite(normalizeSameSite(cookieSameSite))
+                        .path("/")
+        );
+
+        return repository;
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 
                 .csrf(csrf -> csrf
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRepository(csrfTokenRepository())
 
-                        // 조회성 POST API는 데이터 변경이 아니므로 CSRF 검사에서 제외
+                        // 로그인/로그아웃 요청과 조회성 POST API는 CSRF 검사에서 제외
                         .ignoringRequestMatchers(
+                                "/api/auth/login",
+                                "/api/auth/logout",
                                 "/practice/random",
                                 "/practice/bookmarks",
                                 "/api/v1/problems/bookmarked/practice"
@@ -73,6 +99,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/auth/csrf").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/auth/me").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/logout").permitAll()
 
                         // 헬스 체크
                         .requestMatchers(HttpMethod.GET, "/health").permitAll()
@@ -181,6 +208,21 @@ public class SecurityConfig {
             config.setAllowCredentials(true);
 
             return config;
+        };
+    }
+
+    private String normalizeSameSite(String sameSite) {
+        if (sameSite == null || sameSite.isBlank()) {
+            return "Lax";
+        }
+
+        String normalized = sameSite.trim().toLowerCase(Locale.ROOT);
+
+        return switch (normalized) {
+            case "none" -> "None";
+            case "strict" -> "Strict";
+            case "lax" -> "Lax";
+            default -> "Lax";
         };
     }
 

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -19,7 +19,7 @@ server:
       cookie:
         http-only: true
         secure: true
-        same-site: lax
+        same-site: none
 
 app:
   admin:


### PR DESCRIPTION
## 📝 작업 내용 설명

개인용 서비스의 문제/폴더 데이터가 비로그인 사용자에 의해 변경되지 않도록 단일 관리자 로그인과 변경 API 보호를 적용했습니다.

## ✅ 작업 내용

* [x] Spring Security 기반 단일 관리자 로그인 적용
* [x] 문제/폴더 변경 API 인증 처리
* [x] 프론트 관리자 로그인 화면 및 세션 인증 연동

## 🔍 주요 변경 포인트

* 로그인한 사용자만 문제/폴더 생성, 수정, 삭제, 일괄 등록 가능
* 조회성 API는 기존처럼 비로그인 상태에서도 사용 가능
* 운영 환경 쿠키/CSRF 설정을 반영하여 배포 환경 로그인 처리

## 🧪 확인한 내용

* [x] 로컬 환경에서 정상 동작 확인
* [x] 로그인 후 관리 기능 동작 확인
* [x] 비로그인 상태에서 변경 API 차단 확인
* [x] 운영 배포 후 로그인 및 관리 기능 확인

## 📌 비고

* 다중 사용자 회원가입, 역할 분리, OAuth/JWT 구조는 이번 PR 범위에서 제외했습니다.
* 개인용 MVP 단계이므로 로그인한 사용자를 관리자처럼 처리합니다.

## 🔗 관련 이슈

closes #이슈번호
