### PR TITLE
feat(backend/dailyrecord): 일일 풀이 기록 GitHub 자동 업로드 기능 구현

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -72,5 +72,12 @@ jobs:
               -e DB_PASSWORD='${{ secrets.DB_PASSWORD }}' \
               -e JATULI_ADMIN_USERNAME='${{ secrets.JATULI_ADMIN_USERNAME }}' \
               -e JATULI_ADMIN_PASSWORD_HASH='${{ secrets.JATULI_ADMIN_PASSWORD_HASH }}' \
+              -e GITHUB_DAILY_OWNER='hhd1337' \
+              -e GITHUB_DAILY_REPO='jatuli-quiz-daily-records' \
+              -e GITHUB_DAILY_BRANCH='main' \
+              -e GITHUB_DAILY_TOKEN='${{ secrets.JATULI_GITHUB_DAILY_TOKEN }}' \
+              -e GITHUB_DAILY_BASE_PATH='daily' \
+              -e GITHUB_DAILY_COMMITTER_NAME='hhd1337' \
+              -e GITHUB_DAILY_COMMITTER_EMAIL='goeka1337@gmail.com' \
               ${{ env.IMAGE_NAME }}
             docker image prune -f

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/JatuliQuizApplication.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/JatuliQuizApplication.java
@@ -1,10 +1,16 @@
 package com.hhd1337.jatuli_quiz;
 
+import com.hhd1337.jatuli_quiz.config.GithubDailyUploadProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
+@EnableConfigurationProperties(GithubDailyUploadProperties.class)
 @SpringBootApplication
 public class JatuliQuizApplication {
+
     public static void main(String[] args) {
         SpringApplication.run(JatuliQuizApplication.class, args);
     }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/GithubDailyUploadProperties.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/GithubDailyUploadProperties.java
@@ -1,0 +1,16 @@
+package com.hhd1337.jatuli_quiz.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "github.daily-upload")
+public record GithubDailyUploadProperties(
+        boolean enabled,
+        String owner,
+        String repo,
+        String branch,
+        String token,
+        String basePath,
+        String committerName,
+        String committerEmail
+) {
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/RestClientConfig.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.hhd1337.jatuli_quiz.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient.Builder restClientBuilder() {
+        return RestClient.builder();
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/SecurityConfig.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/SecurityConfig.java
@@ -90,7 +90,8 @@ public class SecurityConfig {
                                 "/api/auth/logout",
                                 "/practice/random",
                                 "/practice/bookmarks",
-                                "/api/v1/problems/bookmarked/practice"
+                                "/api/v1/problems/bookmarked/practice",
+                                "/api/v1/test/github-daily-upload"
                         )
                 )
 
@@ -115,6 +116,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/practice/random").permitAll()
                         .requestMatchers(HttpMethod.POST, "/practice/bookmarks").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/problems/bookmarked/practice").permitAll()
+
+                        .requestMatchers(HttpMethod.POST, "/api/v1/test/github-daily-upload").permitAll()
 
                         // 문제 데이터 변경 API 보호
                         .requestMatchers(HttpMethod.POST, "/api/v1/problems").authenticated()

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailyrecord/controller/DailyProblemRecordTestController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailyrecord/controller/DailyProblemRecordTestController.java
@@ -1,0 +1,23 @@
+package com.hhd1337.jatuli_quiz.domain.dailyrecord.controller;
+
+import com.hhd1337.jatuli_quiz.domain.dailyrecord.service.DailyProblemRecordService;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("local")
+@RestController
+@RequiredArgsConstructor
+public class DailyProblemRecordTestController {
+
+    private final DailyProblemRecordService dailyProblemRecordService;
+
+    @PostMapping("/api/v1/test/github-daily-upload")
+    public String uploadDailyRecord(@RequestParam LocalDate date) {
+        dailyProblemRecordService.uploadDailyRecord(date);
+        return "OK";
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailyrecord/converter/DailyProblemMarkdownGenerator.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailyrecord/converter/DailyProblemMarkdownGenerator.java
@@ -1,0 +1,117 @@
+package com.hhd1337.jatuli_quiz.domain.dailyrecord.converter;
+
+import com.hhd1337.jatuli_quiz.domain.dailyrecord.dto.DailySolvedProblemDto;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DailyProblemMarkdownGenerator {
+
+    public String generate(LocalDate targetDate, List<DailySolvedProblemDto> problems) {
+        StringBuilder sb = new StringBuilder();
+
+        appendHeader(sb, targetDate, problems.size());
+
+        for (int i = 0; i < problems.size(); i++) {
+            appendProblem(sb, problems.get(i));
+
+            if (i < problems.size() - 1) {
+                appendProblemSpacing(sb);
+            }
+        }
+
+        //appendFooter(sb);
+
+        return sb.toString();
+    }
+
+    private void appendHeader(StringBuilder sb, LocalDate targetDate, int problemCount) {
+        sb.append("# ")
+                .append(targetDate)
+                .append(" 문제 풀이 기록\n\n");
+
+        sb.append("> [!NOTE]\n");
+        sb.append("> 오늘 풀이한 문제를 자동으로 정리한 기록입니다.  \n");
+        sb.append("> 총 **")
+                .append(problemCount)
+                .append("문제**를 복습했습니다.\n\n");
+
+        sb.append("---\n\n");
+    }
+
+    private void appendProblem(StringBuilder sb, DailySolvedProblemDto problem) {
+        sb.append("## ◉ ")
+                .append(normalizeFolderPath(problem.folderPath()))
+                .append(" [")
+                .append(problem.problemNum())
+                .append("번] ")
+                .append("<sub>누적 ")
+                .append(problem.totalSolvedCount())
+                .append("회</sub>")
+                .append("\n\n");
+
+        sb.append("**")
+                .append(nullToEmpty(problem.question()))
+                .append("**")
+                .append("\n\n");
+
+        appendSection(sb, "해설", problem.explanation());
+        appendSection(sb, "정답", problem.answer());
+    }
+
+    private void appendSection(StringBuilder sb, String title, String content) {
+        sb.append("> **")
+                .append(title)
+                .append("**\n");
+        sb.append(">\n");
+
+        appendBlockquoteContent(sb, nullToEmpty(content));
+
+        sb.append("\n");
+    }
+
+    private void appendBlockquoteContent(StringBuilder sb, String content) {
+        if (content.isBlank()) {
+            sb.append("> _내용 없음_\n");
+            return;
+        }
+
+        String[] lines = content.split("\\R", -1);
+
+        for (String line : lines) {
+            if (line.isBlank()) {
+                sb.append(">\n");
+            } else {
+                sb.append("> ")
+                        .append(line)
+                        .append("\n");
+            }
+        }
+    }
+
+    private void appendProblemSpacing(StringBuilder sb) {
+        sb.append("<br>\n\n");
+    }
+
+    private void appendFooter(StringBuilder sb) {
+        sb.append("<br>\n\n");
+        sb.append("## 🏁 오늘의 기록 끝\n\n");
+        sb.append("");
+    }
+
+    private String normalizeFolderPath(String folderPath) {
+        if (folderPath == null || folderPath.isBlank()) {
+            return "미분류";
+        }
+
+        return folderPath.trim()
+                .replaceAll("/{2,}", "/")
+                .replaceAll("^/+", "")
+                .replaceAll("/+$", "");
+    }
+
+    private String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailyrecord/dto/DailySolvedProblemDto.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailyrecord/dto/DailySolvedProblemDto.java
@@ -1,0 +1,11 @@
+package com.hhd1337.jatuli_quiz.domain.dailyrecord.dto;
+
+public record DailySolvedProblemDto(
+        Integer problemNum,
+        String folderPath,
+        String question,
+        String answer,
+        String explanation,
+        long totalSolvedCount
+) {
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailyrecord/scheduler/DailyProblemRecordScheduler.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailyrecord/scheduler/DailyProblemRecordScheduler.java
@@ -1,0 +1,28 @@
+package com.hhd1337.jatuli_quiz.domain.dailyrecord.scheduler;
+
+import com.hhd1337.jatuli_quiz.domain.dailyrecord.service.DailyProblemRecordService;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyProblemRecordScheduler {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final DailyProblemRecordService dailyProblemRecordService;
+
+    @Scheduled(cron = "0 10 0 * * *", zone = "Asia/Seoul")
+    public void uploadYesterdayProblemRecord() {
+        LocalDate targetDate = LocalDate.now(KST).minusDays(1);
+
+        log.info("[GitHub Daily Upload] 일일 문제 풀이 기록 업로드 시작 targetDate={}", targetDate);
+
+        dailyProblemRecordService.uploadDailyRecord(targetDate);
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailyrecord/service/DailyProblemRecordService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/dailyrecord/service/DailyProblemRecordService.java
@@ -1,0 +1,109 @@
+package com.hhd1337.jatuli_quiz.domain.dailyrecord.service;
+
+import com.hhd1337.jatuli_quiz.config.GithubDailyUploadProperties;
+import com.hhd1337.jatuli_quiz.domain.dailyrecord.converter.DailyProblemMarkdownGenerator;
+import com.hhd1337.jatuli_quiz.domain.dailyrecord.dto.DailySolvedProblemDto;
+import com.hhd1337.jatuli_quiz.domain.folder.entity.Folder;
+import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
+import com.hhd1337.jatuli_quiz.domain.problem.repository.ProblemRepository;
+import com.hhd1337.jatuli_quiz.domain.problemsubmission.repository.ProblemSubmissionRepository;
+import com.hhd1337.jatuli_quiz.infra.github.GithubContentsClient;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DailyProblemRecordService {
+
+    private static final String KST_MIDNIGHT_TIME = "00:00:00";
+
+    private final GithubDailyUploadProperties properties;
+    private final ProblemSubmissionRepository problemSubmissionRepository;
+    private final ProblemRepository problemRepository;
+    private final DailyProblemMarkdownGenerator markdownGenerator;
+    private final GithubContentsClient githubContentsClient;
+
+    @Transactional(readOnly = true)
+    public void uploadDailyRecord(LocalDate targetDate) {
+        if (!properties.enabled()) {
+            log.info("[GitHub Daily Upload] 기능이 비활성화되어 있습니다. targetDate={}", targetDate);
+            return;
+        }
+
+        LocalDateTime startAt = targetDate.atStartOfDay();
+        LocalDateTime endAt = targetDate.plusDays(1).atStartOfDay();
+
+        List<Long> solvedProblemIds = problemSubmissionRepository
+                .findDistinctProblemIdsSolvedBetween(startAt, endAt);
+
+        if (solvedProblemIds.isEmpty()) {
+            log.info("[GitHub Daily Upload] 업로드할 풀이 기록이 없습니다. targetDate={}", targetDate);
+            return;
+        }
+
+        List<Problem> problems = problemRepository.findAllByProblemIdIn(solvedProblemIds);
+
+        List<DailySolvedProblemDto> dailySolvedProblems = problems.stream()
+                .map(problem -> new DailySolvedProblemDto(
+                        problem.getProblemNum(),
+                        resolveFolderPath(problem.getFolder()),
+                        problem.getQuestionText(),
+                        problem.getAnswerText(),
+                        problem.getExplanationText(),
+                        problemSubmissionRepository.countByProblemId(problem.getProblemId())
+                ))
+                .sorted(Comparator
+                        .comparing(DailySolvedProblemDto::folderPath)
+                        .thenComparing(DailySolvedProblemDto::problemNum))
+                .toList();
+
+        String markdown = markdownGenerator.generate(targetDate, dailySolvedProblems);
+        String path = buildGithubFilePath(targetDate);
+        String commitMessage = "docs(daily): " + targetDate + " 문제 풀이 기록 업로드";
+
+        githubContentsClient.createOrUpdateFile(path, markdown, commitMessage);
+
+        log.info(
+                "[GitHub Daily Upload] 일일 문제 풀이 기록 업로드 완료 targetDate={}, problemCount={}, path={}",
+                targetDate,
+                dailySolvedProblems.size(),
+                path
+        );
+    }
+
+    private String buildGithubFilePath(LocalDate targetDate) {
+        return "%s/%d/%02d/%s.md".formatted(
+                properties.basePath(),
+                targetDate.getYear(),
+                targetDate.getMonthValue(),
+                targetDate
+        );
+    }
+
+    private String resolveFolderPath(Folder folder) {
+        if (folder == null) {
+            return "/미분류";
+        }
+
+        List<String> names = new ArrayList<>();
+        Folder current = folder;
+
+        while (current != null) {
+            names.add(current.getName());
+            current = current.getParentFolder();
+        }
+
+        Collections.reverse(names);
+
+        return "/" + String.join("/", names);
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problem/repository/ProblemRepository.java
@@ -5,6 +5,7 @@ import com.hhd1337.jatuli_quiz.domain.problem.entity.Problem;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -124,4 +125,7 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
             order by f.folderId asc, p.problemNum asc, p.problemId asc
             """)
     List<Problem> findAllByFolderIdsForCopy(@Param("folderIds") List<Long> folderIds);
+
+    @EntityGraph(attributePaths = {"folder"})
+    List<Problem> findAllByProblemIdIn(List<Long> problemIds);
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/repository/ProblemSubmissionRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/problemsubmission/repository/ProblemSubmissionRepository.java
@@ -1,7 +1,30 @@
 package com.hhd1337.jatuli_quiz.domain.problemsubmission.repository;
 
 import com.hhd1337.jatuli_quiz.domain.problemsubmission.entity.ProblemSubmission;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProblemSubmissionRepository extends JpaRepository<ProblemSubmission, Long> {
+
+    @Query("""
+            select distinct ps.problem.problemId
+            from ProblemSubmission ps
+            where ps.submittedAt >= :startAt
+              and ps.submittedAt < :endAt
+            order by ps.problem.problemId asc
+            """)
+    List<Long> findDistinctProblemIdsSolvedBetween(
+            @Param("startAt") LocalDateTime startAt,
+            @Param("endAt") LocalDateTime endAt
+    );
+
+    @Query("""
+            select count(ps)
+            from ProblemSubmission ps
+            where ps.problem.problemId = :problemId
+            """)
+    long countByProblemId(@Param("problemId") Long problemId);
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/infra/github/GithubContentsClient.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/infra/github/GithubContentsClient.java
@@ -1,0 +1,95 @@
+package com.hhd1337.jatuli_quiz.infra.github;
+
+import com.hhd1337.jatuli_quiz.config.GithubDailyUploadProperties;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class GithubContentsClient {
+
+    private final GithubDailyUploadProperties properties;
+    private final RestClient restClient;
+
+    public GithubContentsClient(
+            GithubDailyUploadProperties properties,
+            RestClient.Builder restClientBuilder
+    ) {
+        this.properties = properties;
+        this.restClient = restClientBuilder
+                .baseUrl("https://api.github.com")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + properties.token())
+                .defaultHeader(HttpHeaders.ACCEPT, "application/vnd.github+json")
+                .defaultHeader("X-GitHub-Api-Version", "2022-11-28")
+                .build();
+    }
+
+    public void createOrUpdateFile(String path, String markdownContent, String commitMessage) {
+        String existingSha = findExistingFileSha(path);
+
+        String encodedContent = Base64.getEncoder()
+                .encodeToString(markdownContent.getBytes(StandardCharsets.UTF_8));
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("message", commitMessage);
+        body.put("content", encodedContent);
+        body.put("branch", properties.branch());
+
+        Map<String, String> author = new LinkedHashMap<>();
+        author.put("name", properties.committerName());
+        author.put("email", properties.committerEmail());
+        body.put("author", author);
+
+        Map<String, String> committer = new LinkedHashMap<>();
+        committer.put("name", properties.committerName());
+        committer.put("email", properties.committerEmail());
+        body.put("committer", committer);
+
+        if (existingSha != null) {
+            body.put("sha", existingSha);
+        }
+
+        String uri = "/repos/%s/%s/contents/%s"
+                .formatted(properties.owner(), properties.repo(), path);
+
+        restClient.put()
+                .uri(uri)
+                .body(body)
+                .retrieve()
+                .toBodilessEntity();
+
+        if (existingSha == null) {
+            log.info("[GitHub Daily Upload] 새 파일 업로드 완료 path={}", path);
+        } else {
+            log.info("[GitHub Daily Upload] 기존 파일 갱신 완료 path={}", path);
+        }
+    }
+
+    private String findExistingFileSha(String path) {
+        String uri = "/repos/%s/%s/contents/%s?ref=%s"
+                .formatted(properties.owner(), properties.repo(), path, properties.branch());
+
+        try {
+            GithubContentResponse response = restClient.get()
+                    .uri(uri)
+                    .retrieve()
+                    .body(GithubContentResponse.class);
+
+            return response == null ? null : response.sha();
+        } catch (HttpClientErrorException.NotFound e) {
+            return null;
+        }
+    }
+
+    private record GithubContentResponse(
+            String sha
+    ) {
+    }
+}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -32,3 +32,14 @@ app:
       - https://www.jatuli.online
       - https://jatuli-quiz-frontend.vercel.app
       - https://api.jatuli.online
+
+github:
+  daily-upload:
+    enabled: true
+    owner: ${GITHUB_DAILY_OWNER}
+    repo: ${GITHUB_DAILY_REPO}
+    branch: ${GITHUB_DAILY_BRANCH:main}
+    token: ${GITHUB_DAILY_TOKEN}
+    base-path: ${GITHUB_DAILY_BASE_PATH:daily}
+    committer-name: ${GITHUB_DAILY_COMMITTER_NAME:jatuli-bot}
+    committer-email: ${GITHUB_DAILY_COMMITTER_EMAIL:jatuli-bot@example.com}


### PR DESCRIPTION
## 📝 작업 내용 설명

매일 자정 이후 당일 푼 문제 기록을 전용 GitHub 레포지토리에 Markdown 파일로 자동 업로드하는 기능을 구현했습니다.

사용자가 자투리시간에 푼 문제들을 서비스 내부 통계로만 남기는 것이 아니라, 날짜별 학습 기록으로 외부 레포지토리에 자동 저장되도록 하여 학습 이력을 더 명확하게 누적할 수 있도록 했습니다.

이번 작업에서는 `problem_submission` 기록을 기준으로 특정 날짜에 풀이한 문제를 조회하고, 문제 경로, 문제 번호, 문제 내용, 해설, 정답, 누적 풀이 횟수를 Markdown 형식으로 변환한 뒤 GitHub Contents API를 통해 전용 레포지토리에 업로드합니다.

## ✅ 작업 내용

* [x] GitHub 일일 기록 업로드 설정 추가
* [x] 운영 배포 시 GitHub 업로드 관련 환경변수 주입 설정 추가
* [x] 일일 풀이 기록 조회용 Repository 쿼리 추가
* [x] 특정 날짜에 풀이한 문제 목록 조회 기능 구현
* [x] 문제별 누적 풀이 횟수 조회 기능 구현
* [x] GitHub Contents API 업로드 클라이언트 구현
* [x] Markdown 일일 풀이 기록 생성 로직 구현
* [x] 매일 00:10 KST 기준 전날 풀이 기록을 업로드하는 Scheduler 추가
* [x] 로컬 테스트용 일일 기록 업로드 API 추가
* [x] Swagger 로컬 테스트를 위한 Security/CSRF 예외 설정 추가

## 🔍 주요 변경 포인트

* `@Scheduled(cron = "0 10 0 * * *", zone = "Asia/Seoul")` 설정을 통해 매일 00:10 KST에 전날 풀이 기록을 자동 업로드하도록 구성했습니다.
* GitHub 업로드 대상 날짜는 `LocalDate.now(Asia/Seoul).minusDays(1)` 기준으로 계산합니다.
* 해당 날짜에 풀이 기록이 없는 경우 빈 Markdown 파일을 생성하지 않고 로그만 남긴 뒤 종료합니다.
* Markdown 파일은 `daily/yyyy/MM/yyyy-MM-dd.md` 경로로 생성됩니다.
* 같은 날짜의 파일이 이미 존재하는 경우 GitHub Contents API에서 기존 파일의 `sha`를 조회한 뒤 갱신하도록 처리했습니다.
* 커밋 작성자 정보는 GitHub 잔디 반영을 고려해 `author`와 `committer`에 모두 설정되도록 구성했습니다.
* GitHub 토큰은 코드에 직접 작성하지 않고 `JATULI_GITHUB_DAILY_TOKEN` Secret을 통해 배포 시 컨테이너 환경변수로 주입되도록 했습니다.
* 문제 기록 Markdown에는 폴더 경로, 폴더 내 문제 번호, 누적 풀이 횟수, 문제/해설/정답이 구분되어 표시되도록 구성했습니다.

## 🧪 확인한 내용

* [x] 로컬 환경에서 애플리케이션 정상 실행 확인
* [x] Repository 쿼리 생성 오류 수정 확인
* [x] `RestClient.Builder` Bean 등록 오류 수정 확인
* [x] Swagger에서 로컬 테스트 API 호출 확인
* [x] CSRF 설정으로 인한 403 오류 수정 확인
* [x] 특정 날짜 풀이 기록 기준 Markdown 생성 확인
* [x] GitHub 전용 레포지토리에 Markdown 파일 업로드 확인
* [x] 같은 날짜 파일 재업로드 시 기존 파일 갱신 확인
* [x] 풀이 기록이 없는 날짜에는 빈 파일이 생성되지 않는 동작 확인

## 📌 비고

* 운영 환경에서는 GitHub fine-grained personal access token을 `JATULI_GITHUB_DAILY_TOKEN` GitHub Actions Secret으로 관리합니다.
* Docker 컨테이너 내부에서는 Spring 설정과 맞추기 위해 `GITHUB_DAILY_TOKEN` 환경변수로 주입합니다.
* 로컬 테스트용 API는 일일 업로드 기능 검증을 위한 용도입니다.
* 실제 운영 업로드는 매일 00:10 KST에 전날 풀이 기록을 대상으로 수행됩니다.
* GitHub 토큰이 만료되거나 권한이 제거되면 자동 업로드가 실패할 수 있으므로 토큰 만료일 관리가 필요합니다.
* 업로드 대상 전용 레포지토리는 `jatuli-quiz-daily-records`입니다.

## 🔗 관련 이슈

closes #77
