### PR TITLE
feat(routine): 오늘 루틴 시계 MVP 구현

### DIFF
--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/JatuliQuizApplication.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/JatuliQuizApplication.java
@@ -4,8 +4,10 @@ import com.hhd1337.jatuli_quiz.config.GithubDailyUploadProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableJpaAuditing
 @EnableScheduling
 @EnableConfigurationProperties(GithubDailyUploadProperties.class)
 @SpringBootApplication

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/common/entity/BaseEntity.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/common/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.hhd1337.jatuli_quiz.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/SecurityConfig.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/SecurityConfig.java
@@ -84,14 +84,26 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf
                         .csrfTokenRepository(csrfTokenRepository())
 
-                        // 로그인/로그아웃 요청과 조회성 POST API는 CSRF 검사에서 제외
+                        /*
+                         * CSRF 검사 제외 경로
+                         *
+                         * Swagger에서 PUT/PATCH/POST/DELETE 요청을 직접 테스트할 때는
+                         * CSRF 토큰이 자동으로 포함되지 않아 403이 발생할 수 있다.
+                         *
+                         * /api/v1/routines/** 는 현재 루틴 시계 MVP 개발/검증 단계에서만 임시로 제외한다.
+                         * 프론트 연동 후에는 CSRF 토큰을 정상 전송하도록 바꾸고,
+                         * 이 예외는 제거하는 것이 좋다.
+                         */
                         .ignoringRequestMatchers(
                                 "/api/auth/login",
                                 "/api/auth/logout",
                                 "/practice/random",
                                 "/practice/bookmarks",
                                 "/api/v1/problems/bookmarked/practice",
-                                "/api/v1/test/github-daily-upload"
+                                "/api/v1/test/github-daily-upload",
+
+                                // TODO: 개발 단계 Swagger 테스트용 임시 허용
+                                "/api/v1/routines/**"
                         )
                 )
 
@@ -107,6 +119,16 @@ public class SecurityConfig {
 
                         // Swagger는 일단 허용. 운영에서 막고 싶으면 authenticated()로 변경
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+
+                        /*
+                         * TODO: 개발 단계 Swagger 테스트용 임시 허용
+                         *
+                         * 루틴 시계 기능은 최종적으로 로그인 후 사용 가능해야 한다.
+                         * 다만 현재는 프론트 연동 전 Swagger에서 API 동작을 먼저 확인하기 위해 permitAll 처리한다.
+                         *
+                         * 프론트 연동 후에는 아래 설정을 authenticated()로 변경한다.
+                         */
+                        .requestMatchers("/api/v1/routines/**").permitAll()
 
                         // 조회 API 허용
                         .requestMatchers(HttpMethod.GET, "/**").permitAll()

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/controller/RoutineController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/controller/RoutineController.java
@@ -1,0 +1,79 @@
+package com.hhd1337.jatuli_quiz.domain.routine.controller;
+
+import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
+import com.hhd1337.jatuli_quiz.domain.routine.dto.RoutineRequest;
+import com.hhd1337.jatuli_quiz.domain.routine.dto.RoutineResponse;
+import com.hhd1337.jatuli_quiz.domain.routine.service.RoutineService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "Routine API",
+        description = "오늘 루틴 등록, 조회, 완료/건너뜀 처리를 위한 API"
+)
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/routines")
+public class RoutineController {
+
+    private final RoutineService routineService;
+
+    @Operation(
+            summary = "오늘 루틴 저장/수정",
+            description = "사용자가 등록한 특정 날짜의 하루 루틴을 저장하거나 수정합니다. "
+                    + "루틴은 여러 개의 시간 구간으로 구성되며, 각 구간은 교시명, 시작 시간, 종료 시간, 할 일, 정렬 순서, 구간 타입을 가집니다. "
+                    + "이미 해당 날짜의 루틴이 존재하면 기존 루틴을 새 요청 값으로 교체합니다."
+    )
+    @PutMapping("/daily")
+    public ApiResponse<RoutineResponse.DailyRoutineResponse> saveDailyRoutine(
+            @RequestBody RoutineRequest.SaveDailyRoutineRequest request
+    ) {
+        return ApiResponse.onSuccess(routineService.saveDailyRoutine(request));
+    }
+
+    @Operation(
+            summary = "오늘 루틴 조회",
+            description = "요청한 날짜에 등록된 하루 루틴을 조회합니다. "
+                    + "프론트엔드는 응답으로 받은 시간 구간 목록의 시작 시간과 종료 시간을 기준으로 현재 진행 중인 교시를 계산합니다."
+    )
+    @GetMapping("/daily")
+    public ApiResponse<RoutineResponse.DailyRoutineResponse> getDailyRoutine(
+            @RequestParam LocalDate date
+    ) {
+        return ApiResponse.onSuccess(routineService.getDailyRoutine(date));
+    }
+
+    @Operation(
+            summary = "루틴 구간 완료 처리",
+            description = "특정 루틴 시간 구간을 완료 상태로 변경합니다. "
+                    + "예를 들어 현재 2교시 작업을 끝냈을 때 해당 구간을 완료 처리하는 데 사용합니다."
+    )
+    @PatchMapping("/periods/{periodId}/complete")
+    public ApiResponse<RoutineResponse.DailyRoutineResponse> completePeriod(
+            @PathVariable Long periodId
+    ) {
+        return ApiResponse.onSuccess(routineService.completePeriod(periodId));
+    }
+
+    @Operation(
+            summary = "루틴 구간 건너뜀 처리",
+            description = "특정 루틴 시간 구간을 건너뜀 상태로 변경합니다. "
+                    + "해당 교시의 작업을 수행하지 못했거나 의도적으로 넘긴 경우 사용합니다."
+    )
+    @PatchMapping("/periods/{periodId}/skip")
+    public ApiResponse<RoutineResponse.DailyRoutineResponse> skipPeriod(
+            @PathVariable Long periodId
+    ) {
+        return ApiResponse.onSuccess(routineService.skipPeriod(periodId));
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/controller/RoutineController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/controller/RoutineController.java
@@ -76,4 +76,16 @@ public class RoutineController {
     ) {
         return ApiResponse.onSuccess(routineService.skipPeriod(periodId));
     }
+    
+    @Operation(
+            summary = "루틴 구간 대기 상태로 변경",
+            description = "완료 처리된 특정 루틴 시간 구간을 다시 대기 상태로 변경합니다. "
+                    + "사용자가 실수로 완료 처리했거나, 다시 미완료 상태로 되돌리고 싶을 때 사용합니다."
+    )
+    @PatchMapping("/periods/{periodId}/pending")
+    public ApiResponse<RoutineResponse.DailyRoutineResponse> resetPeriod(
+            @PathVariable Long periodId
+    ) {
+        return ApiResponse.onSuccess(routineService.resetPeriod(periodId));
+    }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/converter/RoutineConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/converter/RoutineConverter.java
@@ -1,0 +1,50 @@
+package com.hhd1337.jatuli_quiz.domain.routine.converter;
+
+import com.hhd1337.jatuli_quiz.domain.routine.dto.RoutineRequest;
+import com.hhd1337.jatuli_quiz.domain.routine.dto.RoutineResponse;
+import com.hhd1337.jatuli_quiz.domain.routine.dto.RoutineResponse.RoutinePeriodResponse;
+import com.hhd1337.jatuli_quiz.domain.routine.entity.DailyRoutine;
+import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriod;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoutineConverter {
+
+    public RoutinePeriod toPeriod(RoutineRequest.RoutinePeriodRequest request) {
+        return new RoutinePeriod(
+                request.label(),
+                request.startTime(),
+                request.endTime(),
+                request.taskContent(),
+                request.sortOrder(),
+                request.type()
+        );
+    }
+
+    public RoutineResponse.DailyRoutineResponse toDailyRoutineResponse(DailyRoutine routine) {
+        List<RoutinePeriodResponse> periods = routine.getPeriods()
+                .stream()
+                .map(this::toPeriodResponse)
+                .toList();
+
+        return new RoutineResponse.DailyRoutineResponse(
+                routine.getId(),
+                routine.getRoutineDate(),
+                periods
+        );
+    }
+
+    private RoutineResponse.RoutinePeriodResponse toPeriodResponse(RoutinePeriod period) {
+        return new RoutineResponse.RoutinePeriodResponse(
+                period.getId(),
+                period.getLabel(),
+                period.getStartTime(),
+                period.getEndTime(),
+                period.getTaskContent(),
+                period.getSortOrder(),
+                period.getType(),
+                period.getStatus()
+        );
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/dto/RoutineRequest.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/dto/RoutineRequest.java
@@ -1,0 +1,25 @@
+package com.hhd1337.jatuli_quiz.domain.routine.dto;
+
+import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriodType;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public class RoutineRequest {
+
+    public record SaveDailyRoutineRequest(
+            LocalDate routineDate,
+            List<RoutinePeriodRequest> periods
+    ) {
+    }
+
+    public record RoutinePeriodRequest(
+            String label,
+            LocalTime startTime,
+            LocalTime endTime,
+            String taskContent,
+            Integer sortOrder,
+            RoutinePeriodType type
+    ) {
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/dto/RoutineResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/dto/RoutineResponse.java
@@ -1,0 +1,29 @@
+package com.hhd1337.jatuli_quiz.domain.routine.dto;
+
+import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriodStatus;
+import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriodType;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public class RoutineResponse {
+
+    public record DailyRoutineResponse(
+            Long routineId,
+            LocalDate routineDate,
+            List<RoutinePeriodResponse> periods
+    ) {
+    }
+
+    public record RoutinePeriodResponse(
+            Long periodId,
+            String label,
+            LocalTime startTime,
+            LocalTime endTime,
+            String taskContent,
+            Integer sortOrder,
+            RoutinePeriodType type,
+            RoutinePeriodStatus status
+    ) {
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/DailyRoutine.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/DailyRoutine.java
@@ -1,0 +1,45 @@
+package com.hhd1337.jatuli_quiz.domain.routine.entity;
+
+import com.hhd1337.jatuli_quiz.common.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyRoutine extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate routineDate;
+
+    @OneToMany(mappedBy = "dailyRoutine", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder asc")
+    private List<RoutinePeriod> periods = new ArrayList<>();
+
+    public DailyRoutine(LocalDate routineDate) {
+        this.routineDate = routineDate;
+    }
+
+    public void replacePeriods(List<RoutinePeriod> newPeriods) {
+        this.periods.clear();
+
+        for (RoutinePeriod period : newPeriods) {
+            period.setDailyRoutine(this);
+            this.periods.add(period);
+        }
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/RoutinePeriod.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/RoutinePeriod.java
@@ -78,4 +78,9 @@ public class RoutinePeriod extends BaseEntity {
     public void skip() {
         this.status = RoutinePeriodStatus.SKIPPED;
     }
+
+    public void resetToPending() {
+        this.status = RoutinePeriodStatus.PENDING;
+        this.completedAt = null;
+    }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/RoutinePeriod.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/RoutinePeriod.java
@@ -1,0 +1,81 @@
+package com.hhd1337.jatuli_quiz.domain.routine.entity;
+
+import com.hhd1337.jatuli_quiz.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoutinePeriod extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String label;
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+    @Column(length = 1000)
+    private String taskContent;
+
+    private Integer sortOrder;
+
+    @Enumerated(EnumType.STRING)
+    private RoutinePeriodType type;
+
+    @Enumerated(EnumType.STRING)
+    private RoutinePeriodStatus status;
+
+    private LocalDateTime completedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_routine_id")
+    private DailyRoutine dailyRoutine;
+
+    public RoutinePeriod(
+            String label,
+            LocalTime startTime,
+            LocalTime endTime,
+            String taskContent,
+            Integer sortOrder,
+            RoutinePeriodType type
+    ) {
+        this.label = label;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.taskContent = taskContent;
+        this.sortOrder = sortOrder;
+        this.type = type;
+        this.status = RoutinePeriodStatus.PENDING;
+    }
+
+    public void setDailyRoutine(DailyRoutine dailyRoutine) {
+        this.dailyRoutine = dailyRoutine;
+    }
+
+    public void complete() {
+        this.status = RoutinePeriodStatus.COMPLETED;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void skip() {
+        this.status = RoutinePeriodStatus.SKIPPED;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/RoutinePeriodStatus.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/RoutinePeriodStatus.java
@@ -1,0 +1,7 @@
+package com.hhd1337.jatuli_quiz.domain.routine.entity;
+
+public enum RoutinePeriodStatus {
+    PENDING,
+    COMPLETED,
+    SKIPPED
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/RoutinePeriodType.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/RoutinePeriodType.java
@@ -1,0 +1,7 @@
+package com.hhd1337.jatuli_quiz.domain.routine.entity;
+
+public enum RoutinePeriodType {
+    STUDY,
+    BREAK,
+    ETC
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/repository/DailyRoutineRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/repository/DailyRoutineRepository.java
@@ -1,0 +1,13 @@
+package com.hhd1337.jatuli_quiz.domain.routine.repository;
+
+import com.hhd1337.jatuli_quiz.domain.routine.entity.DailyRoutine;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyRoutineRepository extends JpaRepository<DailyRoutine, Long> {
+
+    Optional<DailyRoutine> findByRoutineDate(LocalDate routineDate);
+
+    boolean existsByRoutineDate(LocalDate routineDate);
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/repository/RoutinePeriodRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/repository/RoutinePeriodRepository.java
@@ -1,0 +1,7 @@
+package com.hhd1337.jatuli_quiz.domain.routine.repository;
+
+import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriod;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoutinePeriodRepository extends JpaRepository<RoutinePeriod, Long> {
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/service/RoutineService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/service/RoutineService.java
@@ -1,0 +1,18 @@
+package com.hhd1337.jatuli_quiz.domain.routine.service;
+
+import com.hhd1337.jatuli_quiz.domain.routine.dto.RoutineRequest;
+import com.hhd1337.jatuli_quiz.domain.routine.dto.RoutineResponse;
+import java.time.LocalDate;
+
+public interface RoutineService {
+
+    RoutineResponse.DailyRoutineResponse saveDailyRoutine(
+            RoutineRequest.SaveDailyRoutineRequest request
+    );
+
+    RoutineResponse.DailyRoutineResponse getDailyRoutine(LocalDate routineDate);
+
+    RoutineResponse.DailyRoutineResponse completePeriod(Long periodId);
+
+    RoutineResponse.DailyRoutineResponse skipPeriod(Long periodId);
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/service/RoutineService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/service/RoutineService.java
@@ -15,4 +15,6 @@ public interface RoutineService {
     RoutineResponse.DailyRoutineResponse completePeriod(Long periodId);
 
     RoutineResponse.DailyRoutineResponse skipPeriod(Long periodId);
+
+    RoutineResponse.DailyRoutineResponse resetPeriod(Long periodId);
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/service/RoutineServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/service/RoutineServiceImpl.java
@@ -98,4 +98,14 @@ public class RoutineServiceImpl implements RoutineService {
 
         return routineConverter.toDailyRoutineResponse(period.getDailyRoutine());
     }
+
+    @Override
+    public RoutineResponse.DailyRoutineResponse resetPeriod(Long periodId) {
+        RoutinePeriod period = routinePeriodRepository.findById(periodId)
+                .orElseThrow(() -> new IllegalArgumentException("루틴 구간을 찾을 수 없습니다."));
+
+        period.resetToPending();
+
+        return routineConverter.toDailyRoutineResponse(period.getDailyRoutine());
+    }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/service/RoutineServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/service/RoutineServiceImpl.java
@@ -1,0 +1,101 @@
+package com.hhd1337.jatuli_quiz.domain.routine.service;
+
+import com.hhd1337.jatuli_quiz.domain.routine.converter.RoutineConverter;
+import com.hhd1337.jatuli_quiz.domain.routine.dto.RoutineRequest;
+import com.hhd1337.jatuli_quiz.domain.routine.dto.RoutineRequest.RoutinePeriodRequest;
+import com.hhd1337.jatuli_quiz.domain.routine.dto.RoutineResponse;
+import com.hhd1337.jatuli_quiz.domain.routine.entity.DailyRoutine;
+import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriod;
+import com.hhd1337.jatuli_quiz.domain.routine.repository.DailyRoutineRepository;
+import com.hhd1337.jatuli_quiz.domain.routine.repository.RoutinePeriodRepository;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RoutineServiceImpl implements RoutineService {
+
+    private final DailyRoutineRepository dailyRoutineRepository;
+    private final RoutinePeriodRepository routinePeriodRepository;
+    private final RoutineConverter routineConverter;
+
+    @Override
+    public RoutineResponse.DailyRoutineResponse saveDailyRoutine(
+            RoutineRequest.SaveDailyRoutineRequest request
+    ) {
+        validatePeriods(request.periods());
+
+        DailyRoutine routine = dailyRoutineRepository.findByRoutineDate(request.routineDate())
+                .orElseGet(() -> new DailyRoutine(request.routineDate()));
+
+        List<RoutinePeriod> periods = request.periods()
+                .stream()
+                .map(routineConverter::toPeriod)
+                .toList();
+
+        routine.replacePeriods(periods);
+
+        DailyRoutine savedRoutine = dailyRoutineRepository.save(routine);
+
+        return routineConverter.toDailyRoutineResponse(savedRoutine);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public RoutineResponse.DailyRoutineResponse getDailyRoutine(LocalDate routineDate) {
+        DailyRoutine routine = dailyRoutineRepository.findByRoutineDate(routineDate)
+                .orElseThrow(() -> new IllegalArgumentException("등록된 오늘 루틴이 없습니다."));
+
+        return routineConverter.toDailyRoutineResponse(routine);
+    }
+
+    private void validatePeriods(List<RoutineRequest.RoutinePeriodRequest> periods) {
+        if (periods == null || periods.isEmpty()) {
+            throw new IllegalArgumentException("루틴 시간 구간은 최소 1개 이상이어야 합니다.");
+        }
+
+        List<RoutinePeriodRequest> sortedPeriods = periods.stream()
+                .sorted(Comparator.comparing(RoutineRequest.RoutinePeriodRequest::startTime))
+                .toList();
+
+        for (RoutineRequest.RoutinePeriodRequest period : sortedPeriods) {
+            if (!period.startTime().isBefore(period.endTime())) {
+                throw new IllegalArgumentException("시작 시간은 종료 시간보다 빨라야 합니다.");
+            }
+        }
+
+        for (int i = 0; i < sortedPeriods.size() - 1; i++) {
+            RoutineRequest.RoutinePeriodRequest current = sortedPeriods.get(i);
+            RoutineRequest.RoutinePeriodRequest next = sortedPeriods.get(i + 1);
+
+            if (current.endTime().isAfter(next.startTime())) {
+                throw new IllegalArgumentException("루틴 시간 구간은 서로 겹칠 수 없습니다.");
+            }
+        }
+    }
+
+    @Override
+    public RoutineResponse.DailyRoutineResponse completePeriod(Long periodId) {
+        RoutinePeriod period = routinePeriodRepository.findById(periodId)
+                .orElseThrow(() -> new IllegalArgumentException("루틴 구간을 찾을 수 없습니다."));
+
+        period.complete();
+
+        return routineConverter.toDailyRoutineResponse(period.getDailyRoutine());
+    }
+
+    @Override
+    public RoutineResponse.DailyRoutineResponse skipPeriod(Long periodId) {
+        RoutinePeriod period = routinePeriodRepository.findById(periodId)
+                .orElseThrow(() -> new IllegalArgumentException("루틴 구간을 찾을 수 없습니다."));
+
+        period.skip();
+
+        return routineConverter.toDailyRoutineResponse(period.getDailyRoutine());
+    }
+}

--- a/frontend/src/app/router.jsx
+++ b/frontend/src/app/router.jsx
@@ -5,19 +5,21 @@ import LoginPage from "../pages/auth/LoginPage";
 import HomePage from "../pages/home/HomePage";
 import QuizPlayPage from "../pages/quiz/QuizPlayPage";
 import QuizEditPage from "../pages/quiz/QuizEditPage";
+import RoutinePage from "../pages/routine/RoutinePage";
 import NotFoundPage from "../pages/error/NotFoundPage";
 import HealthCheckPage from "../pages/test/HealthCheckPage";
 
 export const router = createBrowserRouter([
-  {
-    element: <AppShell />,
-    children: [
-      { path: "/", element: <HomePage /> },
-      { path: "/quiz/play", element: <QuizPlayPage /> },
-      { path: "/quiz/:quizId/edit", element: <QuizEditPage /> },
-      { path: "/test/health", element: <HealthCheckPage /> },
-      { path: "/login", element: <LoginPage /> },
-      { path: "*", element: <NotFoundPage /> },
-    ],
-  },
+    {
+        element: <AppShell />,
+        children: [
+            { path: "/", element: <HomePage /> },
+            { path: "/quiz/play", element: <QuizPlayPage /> },
+            { path: "/quiz/:quizId/edit", element: <QuizEditPage /> },
+            { path: "/routine", element: <RoutinePage /> },
+            { path: "/test/health", element: <HealthCheckPage /> },
+            { path: "/login", element: <LoginPage /> },
+            { path: "*", element: <NotFoundPage /> },
+        ],
+    },
 ]);

--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -1444,54 +1444,32 @@ export default function HomePage() {
             >
                 <div
                     style={{
-                        display: "flex",
-                        justifyContent: "space-between",
-                        alignItems: "flex-start",
-                        gap: 16,
+                        display: "grid",
+                        gridTemplateColumns: "minmax(0, 1fr) auto",
+                        alignItems: "start",
+                        columnGap: 12,
+                        rowGap: 5,
                         marginBottom: 7,
                     }}
                 >
-                    <div
+                    <h1
                         style={{
-                            minWidth: 0,
+                            margin: 0,
+                            fontSize: 30,
+                            lineHeight: 1.15,
+                            letterSpacing: "-0.05em",
                         }}
                     >
-                        <h1
-                            style={{
-                                margin: 0,
-                                fontSize: 30,
-                                lineHeight: 1.15,
-                                letterSpacing: "-0.05em",
-                            }}
-                        >
-                            정진
-                        </h1>
-                        <ol
-                            style={{
-                                ...mutedTextStyle,
-                                marginTop: 5,
-                                marginBottom: 0,
-                                paddingLeft: 15,
-                                fontSize: 10,
-                                lineHeight: 1.7,
-                            }}
-                        >
-                            <li>뜨거운 열정도 중요하지만, 지속적인 열정이 더 중요하다.</li>
-                            <li>나의 목표는 백엔드 개발자로서의 압도적인 기본기와 문제해결 경험이다.</li>
-                            <li>
-                                나는 조급함으로 축적 루틴을 망치지 않고, 거북이 마음으로 쌓아
-                                백엔드 괴물이 된다.
-                            </li>
-                            <li>자신을 믿지 못하는 녀석은 노력할 가치도 없다. 나는 나를 믿는다.</li>
-                        </ol>
-                    </div>
+                        정진
+                    </h1>
 
                     <div
                         style={{
                             display: "flex",
-                            flexDirection: "column",
+                            flexDirection: "row",
                             gap: 8,
-                            alignItems: "flex-end",
+                            alignItems: "center",
+                            justifyContent: "flex-end",
                             flexShrink: 0,
                         }}
                     >
@@ -1500,12 +1478,12 @@ export default function HomePage() {
                             onClick={() => navigate("/routine")}
                             style={{
                                 ...authButtonStyle,
-                                background: "var(--color-primary)",
+                                background: "var(--color-button-bg)",
                                 color: "var(--color-bg)",
                             }}
                             aria-label="루틴 시계로 이동"
                         >
-                            루틴 시계
+                            ⏰
                         </button>
 
                         <button
@@ -1514,7 +1492,6 @@ export default function HomePage() {
                             disabled={authLoading}
                             style={{
                                 ...authButtonStyle,
-                                marginTop: 1,
                                 opacity: authLoading ? 0.6 : 1,
                                 cursor: authLoading ? "not-allowed" : "pointer",
                                 background: isAuthenticated
@@ -1529,6 +1506,26 @@ export default function HomePage() {
                             {authLoading ? "확인 중" : isAuthenticated ? "로그아웃" : "로그인"}
                         </button>
                     </div>
+
+                    <ol
+                        style={{
+                            ...mutedTextStyle,
+                            gridColumn: "1 / -1",
+                            marginTop: 5,
+                            marginBottom: 0,
+                            paddingLeft: 15,
+                            fontSize: 10,
+                            lineHeight: 1.7,
+                        }}
+                    >
+                        <li>뜨거운 열정도 중요하지만, 지속적인 열정이 더 중요하다.</li>
+                        <li>나의 목표는 백엔드 개발자로서의 압도적인 기본기와 문제해결 경험이다.</li>
+                        <li>
+                            나는 조급함으로 축적 루틴을 망치지 않고, 거북이 마음으로 쌓아
+                            백엔드 괴물이 된다.
+                        </li>
+                        <li>자신을 믿지 못하는 녀석은 노력할 가치도 없다. 나는 나를 믿는다.</li>
+                    </ol>
                 </div>
             </header>
 

--- a/frontend/src/pages/home/HomePage.jsx
+++ b/frontend/src/pages/home/HomePage.jsx
@@ -1486,26 +1486,49 @@ export default function HomePage() {
                         </ol>
                     </div>
 
-                    <button
-                        type="button"
-                        onClick={isAuthenticated ? handleLogout : handleGoLogin}
-                        disabled={authLoading}
+                    <div
                         style={{
-                            ...authButtonStyle,
-                            marginTop: 1,
-                            opacity: authLoading ? 0.6 : 1,
-                            cursor: authLoading ? "not-allowed" : "pointer",
-                            background: isAuthenticated
-                                ? "var(--color-primary)"
-                                : "var(--color-button-bg)",
-                            color: isAuthenticated
-                                ? "var(--color-bg)"
-                                : "var(--color-button-text)",
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 8,
+                            alignItems: "flex-end",
+                            flexShrink: 0,
                         }}
-                        aria-label={isAuthenticated ? "로그아웃" : "로그인"}
                     >
-                        {authLoading ? "확인 중" : isAuthenticated ? "로그아웃" : "로그인"}
-                    </button>
+                        <button
+                            type="button"
+                            onClick={() => navigate("/routine")}
+                            style={{
+                                ...authButtonStyle,
+                                background: "var(--color-primary)",
+                                color: "var(--color-bg)",
+                            }}
+                            aria-label="루틴 시계로 이동"
+                        >
+                            루틴 시계
+                        </button>
+
+                        <button
+                            type="button"
+                            onClick={isAuthenticated ? handleLogout : handleGoLogin}
+                            disabled={authLoading}
+                            style={{
+                                ...authButtonStyle,
+                                marginTop: 1,
+                                opacity: authLoading ? 0.6 : 1,
+                                cursor: authLoading ? "not-allowed" : "pointer",
+                                background: isAuthenticated
+                                    ? "var(--color-primary)"
+                                    : "var(--color-button-bg)",
+                                color: isAuthenticated
+                                    ? "var(--color-bg)"
+                                    : "var(--color-button-text)",
+                            }}
+                            aria-label={isAuthenticated ? "로그아웃" : "로그인"}
+                        >
+                            {authLoading ? "확인 중" : isAuthenticated ? "로그아웃" : "로그인"}
+                        </button>
+                    </div>
                 </div>
             </header>
 

--- a/frontend/src/pages/routine/RoutinePage.jsx
+++ b/frontend/src/pages/routine/RoutinePage.jsx
@@ -246,6 +246,30 @@ const textareaStyle = {
     lineHeight: 1.5,
 };
 
+function getTaskTextareaStyle(period) {
+    const isStudy = period?.type === "STUDY";
+
+    return {
+        ...textareaStyle,
+        background: isStudy
+            ? "rgba(245, 158, 11, 0.12)"
+            : "var(--color-bg)",
+        border: isStudy
+            ? "1px solid rgba(245, 158, 11, 0.75)"
+            : "1px solid var(--color-border)",
+        color: isStudy
+            ? "#fff7ed"
+            : "var(--color-text)",
+        fontWeight: isStudy ? 800 : 500,
+        boxShadow: isStudy
+            ? "inset 0 0 0 1px rgba(245, 158, 11, 0.15)"
+            : "none",
+        caretColor: isStudy
+            ? "var(--color-primary)"
+            : "auto",
+    };
+}
+
 function getTodayDateText() {
     const now = new Date();
     const year = now.getFullYear();
@@ -1343,7 +1367,7 @@ export default function RoutinePage() {
                                         }
                                         placeholder="이 시간에 할 일을 적어주세요"
                                         rows={1}
-                                        style={textareaStyle}
+                                        style={getTaskTextareaStyle(period)}
                                     />
                                 </label>
 

--- a/frontend/src/pages/routine/RoutinePage.jsx
+++ b/frontend/src/pages/routine/RoutinePage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
     completeRoutinePeriod,
@@ -12,7 +12,7 @@ const DEFAULT_PERIODS = [
         label: "기상 준비",
         startTime: "05:40:00",
         endTime: "06:00:00",
-        taskContent: "기상, 세수, 책상 앞에 앉기",
+        taskContent: "기상, 계획등록",
         sortOrder: 1,
         type: "ETC",
     },
@@ -25,19 +25,35 @@ const DEFAULT_PERIODS = [
         type: "STUDY",
     },
     {
+        label: "1교시 쉬는시간",
+        startTime: "06:50:00",
+        endTime: "07:00:00",
+        taskContent: "쉬기, 다음 교시 준비",
+        sortOrder: 3,
+        type: "BREAK",
+    },
+    {
         label: "2교시",
         startTime: "07:00:00",
         endTime: "07:50:00",
         taskContent: "",
-        sortOrder: 3,
+        sortOrder: 4,
         type: "STUDY",
+    },
+    {
+        label: "2교시 쉬는시간",
+        startTime: "07:50:00",
+        endTime: "08:00:00",
+        taskContent: "쉬기, 다음 교시 준비",
+        sortOrder: 5,
+        type: "BREAK",
     },
     {
         label: "3교시",
         startTime: "08:00:00",
         endTime: "08:50:00",
         taskContent: "",
-        sortOrder: 4,
+        sortOrder: 6,
         type: "STUDY",
     },
     {
@@ -45,7 +61,7 @@ const DEFAULT_PERIODS = [
         startTime: "08:50:00",
         endTime: "09:20:00",
         taskContent: "샤워",
-        sortOrder: 5,
+        sortOrder: 7,
         type: "BREAK",
     },
     {
@@ -53,31 +69,47 @@ const DEFAULT_PERIODS = [
         startTime: "09:20:00",
         endTime: "10:00:00",
         taskContent: "",
-        sortOrder: 6,
+        sortOrder: 8,
         type: "STUDY",
+    },
+    {
+        label: "4교시 쉬는시간",
+        startTime: "10:00:00",
+        endTime: "10:10:00",
+        taskContent: "쉬기, 다음 교시 준비",
+        sortOrder: 9,
+        type: "BREAK",
     },
     {
         label: "5교시",
         startTime: "10:10:00",
         endTime: "11:00:00",
         taskContent: "",
-        sortOrder: 7,
+        sortOrder: 10,
         type: "STUDY",
+    },
+    {
+        label: "5교시 쉬는시간",
+        startTime: "11:00:00",
+        endTime: "11:10:00",
+        taskContent: "쉬기, 다음 교시 준비",
+        sortOrder: 11,
+        type: "BREAK",
     },
     {
         label: "6교시",
         startTime: "11:10:00",
         endTime: "12:00:00",
         taskContent: "",
-        sortOrder: 8,
+        sortOrder: 12,
         type: "STUDY",
     },
     {
         label: "점심 쉬는 시간",
         startTime: "12:00:00",
         endTime: "15:00:00",
-        taskContent: "쉬기, 준비, 웹 예배하기",
-        sortOrder: 9,
+        taskContent: "3시간 빡 쉬기!",
+        sortOrder: 13,
         type: "BREAK",
     },
     {
@@ -85,7 +117,7 @@ const DEFAULT_PERIODS = [
         startTime: "15:00:00",
         endTime: "16:00:00",
         taskContent: "",
-        sortOrder: 10,
+        sortOrder: 14,
         type: "STUDY",
     },
     {
@@ -93,7 +125,7 @@ const DEFAULT_PERIODS = [
         startTime: "16:00:00",
         endTime: "17:00:00",
         taskContent: "",
-        sortOrder: 11,
+        sortOrder: 15,
         type: "STUDY",
     },
     {
@@ -101,7 +133,7 @@ const DEFAULT_PERIODS = [
         startTime: "17:00:00",
         endTime: "18:00:00",
         taskContent: "",
-        sortOrder: 12,
+        sortOrder: 16,
         type: "STUDY",
     },
     {
@@ -109,7 +141,7 @@ const DEFAULT_PERIODS = [
         startTime: "18:00:00",
         endTime: "19:00:00",
         taskContent: "",
-        sortOrder: 13,
+        sortOrder: 17,
         type: "STUDY",
     },
     {
@@ -117,7 +149,7 @@ const DEFAULT_PERIODS = [
         startTime: "19:00:00",
         endTime: "20:00:00",
         taskContent: "",
-        sortOrder: 14,
+        sortOrder: 18,
         type: "STUDY",
     },
     {
@@ -125,18 +157,21 @@ const DEFAULT_PERIODS = [
         startTime: "20:00:00",
         endTime: "21:00:00",
         taskContent: "",
-        sortOrder: 15,
+        sortOrder: 19,
         type: "STUDY",
     },
     {
         label: "저녁 쉬는 시간",
         startTime: "21:00:00",
         endTime: "22:30:00",
-        taskContent: "쉬기, 준비, 웹 예배하기",
-        sortOrder: 16,
+        taskContent: "집 도착, 1시간쯤 빡 쉬기!",
+        sortOrder: 20,
         type: "BREAK",
     },
 ];
+
+const CLOCK_FONT_FAMILY =
+    "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace";
 
 const pageStyle = {
     width: "100%",
@@ -299,24 +334,6 @@ function findNextPeriod(periods = [], now = new Date()) {
     );
 }
 
-function findPreviousStudyPeriod(periods = [], currentPeriod) {
-    if (!currentPeriod) return null;
-
-    const currentIndex = periods.findIndex((period) => isSamePeriod(period, currentPeriod));
-
-    if (currentIndex <= 0) {
-        return null;
-    }
-
-    for (let index = currentIndex - 1; index >= 0; index -= 1) {
-        if (periods[index].type === "STUDY") {
-            return periods[index];
-        }
-    }
-
-    return null;
-}
-
 function isSamePeriod(left, right) {
     if (!left || !right) return false;
 
@@ -366,6 +383,141 @@ function formatTimeRange(period) {
 
     return `${toTimeInputValue(period.startTime)} ~ ${toTimeInputValue(period.endTime)}`;
 }
+function isTaskTargetPeriod(period) {
+    return period?.type !== "BREAK";
+}
+
+function getPeriodTaskLabel(period) {
+    const task = period?.taskContent?.trim();
+
+    if (!task) {
+        return `${period?.label ?? "루틴"} 할 일 없음`;
+    }
+
+    return task;
+}
+
+function getPeriodIdentity(period) {
+    if (!period) return "";
+
+    return period.periodId
+        ? `id:${period.periodId}`
+        : `${period.label}-${period.startTime}-${period.endTime}`;
+}
+
+function getPreviousUncompletedTaskPeriods(periods = [], currentPeriod, now = new Date()) {
+    const sortedPeriods = sortPeriodsByTime(periods);
+
+    const currentIndex = currentPeriod
+        ? sortedPeriods.findIndex(
+            (period) => getPeriodIdentity(period) === getPeriodIdentity(currentPeriod)
+        )
+        : -1;
+
+    return sortedPeriods.filter((period, index) => {
+        if (!isTaskTargetPeriod(period)) {
+            return false;
+        }
+
+        if (period.status === "COMPLETED") {
+            return false;
+        }
+
+        if (currentIndex >= 0) {
+            return index < currentIndex;
+        }
+
+        const end = parseTodayTime(period.endTime, now);
+
+        return end <= now;
+    });
+}
+
+function buildClockTaskLines({
+                                 previousUncompletedPeriods,
+                                 currentPeriod,
+                                 nextPeriod,
+                             }) {
+    const lines = previousUncompletedPeriods.map((period) => ({
+        key: getPeriodIdentity(period),
+        text: getPeriodTaskLabel(period),
+    }));
+
+    if (currentPeriod) {
+        const isCurrentTaskTarget = isTaskTargetPeriod(currentPeriod);
+
+        if (isCurrentTaskTarget) {
+            if (currentPeriod.status !== "COMPLETED") {
+                lines.push({
+                    key: getPeriodIdentity(currentPeriod),
+                    text: getPeriodTaskLabel(currentPeriod),
+                });
+            }
+
+            if (lines.length > 0) {
+                return lines;
+            }
+
+            return [
+                {
+                    key: "current-completed",
+                    text: "현재 구간의 할 일을 완료했습니다.",
+                },
+            ];
+        }
+
+        if (lines.length > 0) {
+            return lines;
+        }
+
+        return [
+            {
+                key: getPeriodIdentity(currentPeriod),
+                text: getPeriodTaskLabel(currentPeriod),
+            },
+        ];
+    }
+
+    if (nextPeriod) {
+        lines.push({
+            key: getPeriodIdentity(nextPeriod),
+            text: `${nextPeriod.label} · ${formatTimeRange(nextPeriod)} · ${getPeriodTaskLabel(nextPeriod)}`,
+        });
+
+        return lines;
+    }
+
+    if (lines.length > 0) {
+        return lines;
+    }
+
+    return [
+        {
+            key: "done",
+            text: "오늘 등록된 모든 루틴 시간이 끝났습니다.",
+        },
+    ];
+}
+
+function getAutoFitMaxFontSize(lineCount, isClockFullscreen) {
+    if (lineCount <= 1) {
+        return isClockFullscreen ? 42 : 48;
+    }
+
+    if (lineCount === 2) {
+        return isClockFullscreen ? 32 : 34;
+    }
+
+    if (lineCount === 3) {
+        return isClockFullscreen ? 26 : 28;
+    }
+
+    if (lineCount === 4) {
+        return isClockFullscreen ? 22 : 24;
+    }
+
+    return isClockFullscreen ? 18 : 20;
+}
 
 function getStatusText(status) {
     switch (status) {
@@ -378,6 +530,128 @@ function getStatusText(status) {
         default:
             return "대기";
     }
+}
+
+function AutoFitTodoLines({
+                              lines,
+                              color,
+                              isClockFullscreen,
+                          }) {
+    const containerRef = useRef(null);
+    const contentRef = useRef(null);
+
+    const maxFontSize = getAutoFitMaxFontSize(
+        lines.length,
+        isClockFullscreen
+    );
+
+    const minFontSize = isClockFullscreen ? 13 : 14;
+
+    const [fontSize, setFontSize] = useState(maxFontSize);
+
+    useLayoutEffect(() => {
+        function resizeText() {
+            const container = containerRef.current;
+            const content = contentRef.current;
+
+            if (!container || !content) return;
+
+            let nextFontSize = maxFontSize;
+
+            content.style.fontSize = `${nextFontSize}px`;
+
+            while (
+                (content.scrollWidth > container.clientWidth ||
+                    content.scrollHeight > container.clientHeight) &&
+                nextFontSize > minFontSize
+                ) {
+                nextFontSize -= 1;
+                content.style.fontSize = `${nextFontSize}px`;
+            }
+
+            setFontSize(nextFontSize);
+        }
+
+        resizeText();
+
+        const resizeObserver = new ResizeObserver(resizeText);
+
+        if (containerRef.current) {
+            resizeObserver.observe(containerRef.current);
+        }
+
+        window.addEventListener("resize", resizeText);
+
+        return () => {
+            resizeObserver.disconnect();
+            window.removeEventListener("resize", resizeText);
+        };
+    }, [lines, maxFontSize, minFontSize]);
+
+    if (!lines.length) {
+        return null;
+    }
+
+    return (
+        <div
+            ref={containerRef}
+            style={{
+                width: "100%",
+                maxWidth: "100%",
+                maxHeight: isClockFullscreen ? "34dvh" : "24dvh",
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                overflow: "hidden",
+            }}
+        >
+            {lines.length === 1 ? (
+                <div
+                    ref={contentRef}
+                    style={{
+                        width: "100%",
+                        color,
+                        fontSize,
+                        fontWeight: 900,
+                        lineHeight: 1.25,
+                        letterSpacing: "-0.06em",
+                        whiteSpace: "nowrap",
+                        textAlign: "center",
+                    }}
+                >
+                    {lines[0].text}
+                </div>
+            ) : (
+                <ol
+                    ref={contentRef}
+                    style={{
+                        width: "max-content",
+                        maxWidth: "100%",
+                        margin: 0,
+                        paddingLeft: 0,
+                        color,
+                        fontSize,
+                        fontWeight: 900,
+                        lineHeight: 1.35,
+                        letterSpacing: "-0.05em",
+                        textAlign: "left",
+                        listStylePosition: "inside",
+                    }}
+                >
+                    {lines.map((line) => (
+                        <li
+                            key={line.key}
+                            style={{
+                                whiteSpace: "nowrap",
+                            }}
+                        >
+                            {line.text}
+                        </li>
+                    ))}
+                </ol>
+            )}
+        </div>
+    );
 }
 
 function isStudyPeriod(period) {
@@ -524,6 +798,8 @@ export default function RoutinePage() {
     const [isEditMode, setIsEditMode] = useState(false);
     const [message, setMessage] = useState("");
 
+    const [isClockFullscreen, setIsClockFullscreen] = useState(false);
+
     const orderedPeriods = useMemo(
         () => sortPeriodsByTime(routine?.periods ?? []),
         [routine]
@@ -539,22 +815,24 @@ export default function RoutinePage() {
         [orderedPeriods, now]
     );
 
-    const previousStudyPeriod = useMemo(
-        () => findPreviousStudyPeriod(orderedPeriods, currentPeriod),
-        [orderedPeriods, currentPeriod]
+    const previousUncompletedTaskPeriods = useMemo(
+        () => getPreviousUncompletedTaskPeriods(orderedPeriods, currentPeriod, now),
+        [orderedPeriods, currentPeriod, now]
+    );
+
+    const clockTaskLines = useMemo(
+        () =>
+            buildClockTaskLines({
+                previousUncompletedPeriods: previousUncompletedTaskPeriods,
+                currentPeriod,
+                nextPeriod,
+            }),
+        [previousUncompletedTaskPeriods, currentPeriod, nextPeriod]
     );
 
     const isBreakTime = currentPeriod?.type === "BREAK";
 
     const clockTitle = useMemo(() => {
-        if (currentPeriod && isBreakTime) {
-            if (previousStudyPeriod?.label) {
-                return `${previousStudyPeriod.label} 쉬는시간!`;
-            }
-
-            return "쉬는시간!";
-        }
-
         if (currentPeriod) {
             return currentPeriod.label;
         }
@@ -564,7 +842,7 @@ export default function RoutinePage() {
         }
 
         return "오늘 루틴 종료";
-    }, [currentPeriod, isBreakTime, nextPeriod, previousStudyPeriod]);
+    }, [currentPeriod, nextPeriod]);
 
     const clockSeconds = useMemo(() => {
         if (currentPeriod) {
@@ -577,20 +855,6 @@ export default function RoutinePage() {
 
         return 0;
     }, [currentPeriod, nextPeriod, now]);
-
-    const clockTaskText = useMemo(() => {
-        if (currentPeriod) {
-            return currentPeriod.taskContent?.trim() || "할 일이 비어 있습니다.";
-        }
-
-        if (nextPeriod) {
-            return `${nextPeriod.label} · ${formatTimeRange(nextPeriod)} · ${
-                nextPeriod.taskContent?.trim() || "할 일이 비어 있습니다."
-            }`;
-        }
-
-        return "오늘 등록된 모든 루틴 시간이 끝났습니다.";
-    }, [currentPeriod, nextPeriod]);
 
     useEffect(() => {
         const timerId = window.setInterval(() => {
@@ -751,27 +1015,6 @@ export default function RoutinePage() {
         }
     }
 
-    async function handleCompleteCurrentPeriod() {
-        if (!currentPeriod?.periodId) {
-            alert("저장된 루틴 구간만 완료 처리할 수 있습니다.");
-            return;
-        }
-
-        try {
-            setSubmittingStatus(true);
-
-            const updatedRoutine = await completeRoutinePeriod(currentPeriod.periodId);
-
-            setRoutine(updatedRoutine);
-            setFormPeriods(toFormPeriods(updatedRoutine.periods));
-        } catch (error) {
-            console.error("루틴 완료 처리 실패:", error);
-            alert(getApiErrorMessage(error, "루틴 완료 처리에 실패했습니다."));
-        } finally {
-            setSubmittingStatus(false);
-        }
-    }
-
     async function handleTogglePeriodCompleted(period) {
         if (!period?.periodId) {
             alert("저장된 루틴 구간만 상태를 변경할 수 있습니다.");
@@ -788,30 +1031,10 @@ export default function RoutinePage() {
 
             setRoutine(updatedRoutine);
             setFormPeriods(toFormPeriods(updatedRoutine.periods));
+            setNow(new Date());
         } catch (error) {
             console.error("루틴 상태 변경 실패:", error);
             alert(getApiErrorMessage(error, "루틴 상태 변경에 실패했습니다."));
-        } finally {
-            setSubmittingStatus(false);
-        }
-    }
-
-    async function handleSkipCurrentPeriod() {
-        if (!currentPeriod?.periodId) {
-            alert("저장된 루틴 구간만 건너뜀 처리할 수 있습니다.");
-            return;
-        }
-
-        try {
-            setSubmittingStatus(true);
-
-            const updatedRoutine = await skipRoutinePeriod(currentPeriod.periodId);
-
-            setRoutine(updatedRoutine);
-            setFormPeriods(toFormPeriods(updatedRoutine.periods));
-        } catch (error) {
-            console.error("루틴 건너뜀 처리 실패:", error);
-            alert(getApiErrorMessage(error, "루틴 건너뜀 처리에 실패했습니다."));
         } finally {
             setSubmittingStatus(false);
         }
@@ -855,7 +1078,7 @@ export default function RoutinePage() {
                             fontSize: 13,
                         }}
                     >
-                        {todayDate} · 현재 시간 기준으로 교시와 할 일을 자동 표시합니다.
+                        {todayDate} · 현재 시간 기준
                     </p>
                 </div>
 
@@ -1174,9 +1397,30 @@ export default function RoutinePage() {
             ) : (
                 <>
                     <section
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => {
+                            if (!isClockFullscreen) {
+                                setIsClockFullscreen(true);
+                            }
+                        }}
+                        onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                                event.preventDefault();
+
+                                if (!isClockFullscreen) {
+                                    setIsClockFullscreen(true);
+                                }
+                            }
+                        }}
                         style={{
-                            minHeight: "min(70vh, 620px)",
-                            borderRadius: 24,
+                            position: isClockFullscreen ? "fixed" : "relative",
+                            inset: isClockFullscreen ? 0 : "auto",
+                            zIndex: isClockFullscreen ? 9999 : "auto",
+                            width: isClockFullscreen ? "100vw" : "100%",
+                            minHeight: isClockFullscreen ? "100dvh" : "min(70vh, 620px)",
+                            height: isClockFullscreen ? "100dvh" : "auto",
+                            borderRadius: isClockFullscreen ? 0 : 24,
                             border: isBreakTime
                                 ? "1px solid #e5e7eb"
                                 : "1px solid #111827",
@@ -1187,66 +1431,72 @@ export default function RoutinePage() {
                             alignItems: "center",
                             justifyContent: "center",
                             textAlign: "center",
-                            padding: "clamp(28px, 8vw, 72px) clamp(14px, 5vw, 48px)",
+                            padding: isClockFullscreen
+                                ? "calc(env(safe-area-inset-top) + 14px) calc(env(safe-area-inset-right) + 14px) calc(env(safe-area-inset-bottom) + 14px) calc(env(safe-area-inset-left) + 14px)"
+                                : "clamp(28px, 8vw, 72px) clamp(14px, 5vw, 48px)",
                             boxSizing: "border-box",
-                            boxShadow: "0 18px 55px rgba(0, 0, 0, 0.35)",
+                            boxShadow: isClockFullscreen
+                                ? "none"
+                                : "0 18px 55px rgba(0, 0, 0, 0.35)",
+                            cursor: isClockFullscreen ? "default" : "pointer",
                         }}
                     >
-                        <div
-                            style={{
-                                color: isBreakTime ? "#111827" : "#facc15",
-                                fontSize: "clamp(38px, 11vw, 86px)",
-                                fontWeight: 900,
-                                lineHeight: 1.05,
-                                letterSpacing: "-0.08em",
-                                marginBottom: "clamp(20px, 4vw, 28px)",
-                            }}
-                        >
-                            {clockTitle}
-                        </div>
-
-                        <div
-                            style={{
-                                color: isBreakTime ? "#111827" : "#ffffff",
-                                fontFamily:
-                                    "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
-                                fontSize: "clamp(52px, 16vw, 132px)",
-                                fontWeight: 900,
-                                lineHeight: 1,
-                                letterSpacing: "-0.08em",
-                                marginBottom: "clamp(28px, 5vw, 46px)",
-                            }}
-                        >
-                            {formatClockTime(clockSeconds)}
-                        </div>
-
-                        <div
-                            style={{
-                                color: isBreakTime ? "#111827" : "#fb7185",
-                                fontSize: "clamp(22px, 6vw, 48px)",
-                                fontWeight: 800,
-                                lineHeight: 1.35,
-                                letterSpacing: "-0.06em",
-                                maxWidth: 900,
-                                wordBreak: "keep-all",
-                                overflowWrap: "break-word",
-                            }}
-                        >
-                            {clockTaskText}
-                        </div>
-
-                        {currentPeriod && (
-                            <div
+                        {isClockFullscreen && (
+                            <button
+                                type="button"
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    setIsClockFullscreen(false);
+                                }}
                                 style={{
-                                    display: "flex",
-                                    gap: 8,
-                                    justifyContent: "center",
-                                    flexWrap: "wrap",
-                                    marginTop: 28,
-                                    fontSize: 14,
-                                    fontWeight: 800,
+                                    position: "absolute",
+                                    top: "calc(env(safe-area-inset-top) + 12px)",
+                                    right: "calc(env(safe-area-inset-right) + 12px)",
+                                    border: isBreakTime ? "1px solid #111827" : "1px solid #374151",
+                                    background: isBreakTime ? "#ffffff" : "#111827",
+                                    color: isBreakTime ? "#111827" : "#ffffff",
+                                    borderRadius: 999,
+                                    padding: "9px 13px",
+                                    fontSize: 13,
+                                    fontWeight: 900,
+                                    cursor: "pointer",
                                 }}
                             >
+                                닫기
+                            </button>
+                        )}
+                        <div
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                gap: "clamp(8px, 2vw, 16px)",
+                                marginBottom: isClockFullscreen
+                                    ? "clamp(10px, 2vw, 18px)"
+                                    : "clamp(20px, 4vw, 28px)",
+                                marginLeft: isClockFullscreen
+                                    ? 80
+                                    : 0,
+                                maxWidth: "100%",
+                                flexWrap: "wrap",
+                            }}
+                        >
+                            <div
+                                style={{
+                                    color: isBreakTime ? "#111827" : "#facc15",
+                                    fontSize: isClockFullscreen
+                                        ? "clamp(28px, 7vw, 60px)"
+                                        : "clamp(38px, 11vw, 86px)",
+                                    fontWeight: 900,
+                                    lineHeight: 1.05,
+                                    letterSpacing: "-0.08em",
+                                    whiteSpace: "nowrap",
+                                }}
+                            >
+                                {clockTitle}
+                            </div>
+
+                            {currentPeriod && (
                                 <span
                                     style={{
                                         border: isBreakTime
@@ -1255,25 +1505,51 @@ export default function RoutinePage() {
                                         borderRadius: 999,
                                         padding: "7px 12px",
                                         color: isBreakTime ? "#111827" : "#d1d5db",
+                                        fontSize: isClockFullscreen ? 12 : 14,
+                                        fontWeight: 800,
+                                        whiteSpace: "nowrap",
+                                        letterSpacing: "-0.02em",
                                     }}
                                 >
                                     {formatTimeRange(currentPeriod)}
                                 </span>
+                            )}
+                        </div>
 
-                                <span
-                                    style={{
-                                        border: isBreakTime
-                                            ? "1px solid #111827"
-                                            : "1px solid #374151",
-                                        borderRadius: 999,
-                                        padding: "7px 12px",
-                                        color: isBreakTime ? "#111827" : "#d1d5db",
-                                    }}
-                                >
-                                    {getStatusText(currentPeriod.status)}
-                                </span>
+                        <div
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                gap: "clamp(10px, 2vw, 18px)",
+                                marginBottom: isClockFullscreen
+                                    ? "clamp(14px, 3vw, 26px)"
+                                    : "clamp(28px, 5vw, 46px)",
+                                maxWidth: "100%",
+                            }}
+                        >
+                            <div
+                                style={{
+                                    color: isBreakTime ? "#111827" : "#ffffff",
+                                    fontFamily: CLOCK_FONT_FAMILY,
+                                    fontSize: isClockFullscreen
+                                        ? "clamp(42px, 12vw, 92px)"
+                                        : "clamp(52px, 16vw, 132px)",
+                                    fontWeight: 900,
+                                    lineHeight: 1,
+                                    letterSpacing: "-0.08em",
+                                    whiteSpace: "nowrap",
+                                }}
+                            >
+                                {formatClockTime(clockSeconds)}
                             </div>
-                        )}
+                        </div>
+
+                        <AutoFitTodoLines
+                            lines={clockTaskLines}
+                            color={isBreakTime ? "#111827" : "#fb7185"}
+                            isClockFullscreen={isClockFullscreen}
+                        />
 
                     </section>
 
@@ -1369,18 +1645,28 @@ export default function RoutinePage() {
                                             {period.taskContent || "할 일 없음"}
                                         </span>
 
-                                        <button
-                                            type="button"
-                                            onClick={() => handleTogglePeriodCompleted(period)}
-                                            disabled={submittingStatus}
-                                            style={{
-                                                ...getPeriodStatusButtonStyle(period),
-                                                opacity: submittingStatus ? 0.65 : 1,
-                                                cursor: submittingStatus ? "not-allowed" : "pointer",
-                                            }}
-                                        >
-                                            {period.status === "COMPLETED" ? "완료" : "대기"}
-                                        </button>
+                                        {period.type !== "BREAK" ? (
+                                            <button
+                                                type="button"
+                                                onClick={() => handleTogglePeriodCompleted(period)}
+                                                disabled={submittingStatus}
+                                                style={{
+                                                    ...getPeriodStatusButtonStyle(period),
+                                                    opacity: submittingStatus ? 0.65 : 1,
+                                                    cursor: submittingStatus ? "not-allowed" : "pointer",
+                                                }}
+                                            >
+                                                {period.status === "COMPLETED" ? "완료" : "대기"}
+                                            </button>
+                                        ) : (
+                                            <span
+                                                aria-hidden="true"
+                                                style={{
+                                                    width: 52,
+                                                    height: 30,
+                                                }}
+                                            />
+                                        )}
                                     </div>
                                 );
                             })}

--- a/frontend/src/pages/routine/RoutinePage.jsx
+++ b/frontend/src/pages/routine/RoutinePage.jsx
@@ -1,0 +1,1393 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+    completeRoutinePeriod,
+    getDailyRoutine,
+    resetRoutinePeriod,
+    saveDailyRoutine,
+} from "../../shared/api/routineApi";
+
+const DEFAULT_PERIODS = [
+    {
+        label: "기상 준비",
+        startTime: "05:40:00",
+        endTime: "06:00:00",
+        taskContent: "기상, 세수, 책상 앞에 앉기",
+        sortOrder: 1,
+        type: "ETC",
+    },
+    {
+        label: "1교시",
+        startTime: "06:00:00",
+        endTime: "06:50:00",
+        taskContent: "",
+        sortOrder: 2,
+        type: "STUDY",
+    },
+    {
+        label: "2교시",
+        startTime: "07:00:00",
+        endTime: "07:50:00",
+        taskContent: "",
+        sortOrder: 3,
+        type: "STUDY",
+    },
+    {
+        label: "3교시",
+        startTime: "08:00:00",
+        endTime: "08:50:00",
+        taskContent: "",
+        sortOrder: 4,
+        type: "STUDY",
+    },
+    {
+        label: "샤워시간",
+        startTime: "08:50:00",
+        endTime: "09:20:00",
+        taskContent: "샤워",
+        sortOrder: 5,
+        type: "BREAK",
+    },
+    {
+        label: "4교시",
+        startTime: "09:20:00",
+        endTime: "10:00:00",
+        taskContent: "",
+        sortOrder: 6,
+        type: "STUDY",
+    },
+    {
+        label: "5교시",
+        startTime: "10:10:00",
+        endTime: "11:00:00",
+        taskContent: "",
+        sortOrder: 7,
+        type: "STUDY",
+    },
+    {
+        label: "6교시",
+        startTime: "11:10:00",
+        endTime: "12:00:00",
+        taskContent: "",
+        sortOrder: 8,
+        type: "STUDY",
+    },
+    {
+        label: "점심 쉬는 시간",
+        startTime: "12:00:00",
+        endTime: "15:00:00",
+        taskContent: "쉬기, 준비, 웹 예배하기",
+        sortOrder: 9,
+        type: "BREAK",
+    },
+    {
+        label: "야자 1교시",
+        startTime: "15:00:00",
+        endTime: "16:00:00",
+        taskContent: "",
+        sortOrder: 10,
+        type: "STUDY",
+    },
+    {
+        label: "야자 2교시",
+        startTime: "16:00:00",
+        endTime: "17:00:00",
+        taskContent: "",
+        sortOrder: 11,
+        type: "STUDY",
+    },
+    {
+        label: "야자 3교시",
+        startTime: "17:00:00",
+        endTime: "18:00:00",
+        taskContent: "",
+        sortOrder: 12,
+        type: "STUDY",
+    },
+    {
+        label: "야자 4교시",
+        startTime: "18:00:00",
+        endTime: "19:00:00",
+        taskContent: "",
+        sortOrder: 13,
+        type: "STUDY",
+    },
+    {
+        label: "야자 5교시",
+        startTime: "19:00:00",
+        endTime: "20:00:00",
+        taskContent: "",
+        sortOrder: 14,
+        type: "STUDY",
+    },
+    {
+        label: "야자 6교시",
+        startTime: "20:00:00",
+        endTime: "21:00:00",
+        taskContent: "",
+        sortOrder: 15,
+        type: "STUDY",
+    },
+    {
+        label: "저녁 쉬는 시간",
+        startTime: "21:00:00",
+        endTime: "22:30:00",
+        taskContent: "쉬기, 준비, 웹 예배하기",
+        sortOrder: 16,
+        type: "BREAK",
+    },
+];
+
+const pageStyle = {
+    width: "100%",
+    maxWidth: 960,
+    margin: "0 auto",
+    padding: "28px clamp(10px, 3vw, 22px) 56px",
+    color: "var(--color-text)",
+    boxSizing: "border-box",
+};
+
+const cardStyle = {
+    width: "100%",
+    boxSizing: "border-box",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-surface)",
+    color: "var(--color-text)",
+    borderRadius: 18,
+    padding: "clamp(16px, 4vw, 22px)",
+};
+
+const softCardStyle = {
+    width: "100%",
+    boxSizing: "border-box",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-surface)",
+    color: "var(--color-text)",
+    borderRadius: 14,
+    padding: "14px",
+};
+
+const mutedTextStyle = {
+    color: "var(--color-text-muted)",
+};
+
+const buttonBaseStyle = {
+    border: "1px solid var(--color-border)",
+    background: "var(--color-button-bg)",
+    color: "var(--color-button-text)",
+    padding: "10px 14px",
+    borderRadius: 10,
+    fontWeight: 800,
+    fontSize: 14,
+    cursor: "pointer",
+};
+
+const primaryButtonStyle = {
+    ...buttonBaseStyle,
+    background: "var(--color-primary)",
+    color: "var(--color-bg)",
+};
+
+const dangerButtonStyle = {
+    ...buttonBaseStyle,
+    color: "#fca5a5",
+};
+
+const inputStyle = {
+    width: "100%",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-bg)",
+    color: "var(--color-text)",
+    borderRadius: 10,
+    padding: "9px 10px",
+    fontSize: 14,
+    boxSizing: "border-box",
+};
+
+const textareaStyle = {
+    ...inputStyle,
+    minHeight: 42,
+    resize: "vertical",
+    lineHeight: 1.5,
+};
+
+function getTodayDateText() {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const date = String(now.getDate()).padStart(2, "0");
+
+    return `${year}-${month}-${date}`;
+}
+
+function cloneDefaultPeriods() {
+    return DEFAULT_PERIODS.map((period) => ({ ...period }));
+}
+
+function toTimeInputValue(timeText) {
+    if (!timeText) return "";
+    return String(timeText).slice(0, 5);
+}
+
+function normalizeTimeForApi(timeText) {
+    if (!timeText) return "00:00:00";
+
+    const parts = String(timeText).split(":");
+
+    const hour = String(parts[0] ?? "00").padStart(2, "0");
+    const minute = String(parts[1] ?? "00").padStart(2, "0");
+    const second = String(parts[2] ?? "00").padStart(2, "0");
+
+    return `${hour}:${minute}:${second}`;
+}
+
+function normalizeTimeInputText(value) {
+    if (!value) return "";
+
+    const onlyTimeText = String(value)
+        .trim()
+        .replace(/[^\d:]/g, "");
+
+    const [rawHour = "", rawMinute = ""] = onlyTimeText.split(":");
+
+    const hour = Math.max(0, Math.min(23, Number(rawHour || 0)));
+    const minute = Math.max(0, Math.min(59, Number(rawMinute || 0)));
+
+    return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+function parseTodayTime(timeText, baseDate = new Date()) {
+    const normalized = normalizeTimeForApi(timeText);
+    const [hour, minute, second] = normalized.split(":");
+
+    const date = new Date(baseDate);
+    date.setHours(Number(hour), Number(minute), Number(second), 0);
+
+    return date;
+}
+
+function sortPeriodsByTime(periods = []) {
+    return [...periods].sort((a, b) => {
+        const startCompare = String(a.startTime).localeCompare(String(b.startTime));
+
+        if (startCompare !== 0) {
+            return startCompare;
+        }
+
+        return Number(a.sortOrder ?? 0) - Number(b.sortOrder ?? 0);
+    });
+}
+
+function findCurrentPeriod(periods = [], now = new Date()) {
+    return (
+        periods.find((period) => {
+            const start = parseTodayTime(period.startTime, now);
+            const end = parseTodayTime(period.endTime, now);
+
+            return start <= now && now < end;
+        }) ?? null
+    );
+}
+
+function findNextPeriod(periods = [], now = new Date()) {
+    return (
+        periods.find((period) => {
+            const start = parseTodayTime(period.startTime, now);
+
+            return now < start;
+        }) ?? null
+    );
+}
+
+function findPreviousStudyPeriod(periods = [], currentPeriod) {
+    if (!currentPeriod) return null;
+
+    const currentIndex = periods.findIndex((period) => isSamePeriod(period, currentPeriod));
+
+    if (currentIndex <= 0) {
+        return null;
+    }
+
+    for (let index = currentIndex - 1; index >= 0; index -= 1) {
+        if (periods[index].type === "STUDY") {
+            return periods[index];
+        }
+    }
+
+    return null;
+}
+
+function isSamePeriod(left, right) {
+    if (!left || !right) return false;
+
+    if (left.periodId && right.periodId) {
+        return left.periodId === right.periodId;
+    }
+
+    return (
+        left.label === right.label &&
+        left.startTime === right.startTime &&
+        left.endTime === right.endTime
+    );
+}
+
+function getElapsedSeconds(period, now = new Date()) {
+    if (!period) return 0;
+
+    const start = parseTodayTime(period.startTime, now);
+
+    return Math.max(0, Math.floor((now - start) / 1000));
+}
+
+function getRemainingSecondsUntilPeriod(period, now = new Date()) {
+    if (!period) return 0;
+
+    const start = parseTodayTime(period.startTime, now);
+
+    return Math.max(0, Math.floor((start - now) / 1000));
+}
+
+function formatClockTime(totalSeconds) {
+    const safeSeconds = Math.max(0, Number(totalSeconds) || 0);
+
+    const hours = Math.floor(safeSeconds / 3600);
+    const minutes = Math.floor((safeSeconds % 3600) / 60);
+    const seconds = safeSeconds % 60;
+
+    return [
+        String(hours).padStart(2, "0"),
+        String(minutes).padStart(2, "0"),
+        String(seconds).padStart(2, "0"),
+    ].join(":");
+}
+
+function formatTimeRange(period) {
+    if (!period) return "";
+
+    return `${toTimeInputValue(period.startTime)} ~ ${toTimeInputValue(period.endTime)}`;
+}
+
+function getStatusText(status) {
+    switch (status) {
+        case "COMPLETED":
+            return "완료";
+        case "SKIPPED":
+            return "건너뜀";
+        case "PENDING":
+            return "대기";
+        default:
+            return "대기";
+    }
+}
+
+function isStudyPeriod(period) {
+    return period?.type === "STUDY";
+}
+
+function getPeriodCardVisualStyle(period, active = false) {
+    const study = isStudyPeriod(period);
+
+    if (active) {
+        return {
+            background: study
+                ? "rgba(245, 158, 11, 0.18)"
+                : "#3a3f46",
+            borderColor: study
+                ? "var(--color-primary)"
+                : "#4b5563",
+        };
+    }
+
+    return {
+        background: study ? "#050505" : "#2f333b",
+        borderColor: "#374151",
+    };
+}
+
+function getPeriodStatusButtonStyle(period) {
+    const completed = period?.status === "COMPLETED";
+
+    return {
+        border: completed
+            ? "1px solid var(--color-primary)"
+            : "1px solid var(--color-border)",
+        background: completed
+            ? "var(--color-primary)"
+            : "transparent",
+        color: completed
+            ? "var(--color-bg)"
+            : "var(--color-text-muted)",
+        borderRadius: 999,
+        padding: "6px 11px",
+        fontSize: 12,
+        fontWeight: 900,
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+    };
+}
+
+function addMinutesToTime(timeText, minutesToAdd) {
+    const normalized = normalizeTimeForApi(timeText);
+    const [hour, minute] = normalized.split(":").map(Number);
+
+    const totalMinutes = hour * 60 + minute + minutesToAdd;
+    const clampedMinutes = Math.max(0, Math.min(23 * 60 + 59, totalMinutes));
+
+    const nextHour = Math.floor(clampedMinutes / 60);
+    const nextMinute = clampedMinutes % 60;
+
+    return `${String(nextHour).padStart(2, "0")}:${String(nextMinute).padStart(2, "0")}:00`;
+}
+
+function validatePeriods(periods) {
+    if (!periods.length) {
+        return "루틴 구간은 최소 1개 이상이어야 합니다.";
+    }
+
+    const sortedPeriods = sortPeriodsByTime(periods);
+
+    for (const period of sortedPeriods) {
+        if (!period.label?.trim()) {
+            return "교시명/구간명을 입력해주세요.";
+        }
+
+        if (!period.startTime || !period.endTime) {
+            return "시작 시간과 종료 시간을 모두 입력해주세요.";
+        }
+
+        const start = parseTodayTime(period.startTime);
+        const end = parseTodayTime(period.endTime);
+
+        if (start >= end) {
+            return `'${period.label}' 구간의 시작 시간은 종료 시간보다 빨라야 합니다.`;
+        }
+    }
+
+    for (let index = 0; index < sortedPeriods.length - 1; index += 1) {
+        const current = sortedPeriods[index];
+        const next = sortedPeriods[index + 1];
+
+        const currentEnd = parseTodayTime(current.endTime);
+        const nextStart = parseTodayTime(next.startTime);
+
+        if (currentEnd > nextStart) {
+            return `'${current.label}' 구간과 '${next.label}' 구간의 시간이 겹칩니다.`;
+        }
+    }
+
+    return "";
+}
+
+function getApiErrorMessage(error, fallbackMessage) {
+    return (
+        error?.response?.data?.message ||
+        error?.response?.data?.result?.message ||
+        fallbackMessage
+    );
+}
+
+function toFormPeriods(periods = []) {
+    return sortPeriodsByTime(periods).map((period, index) => ({
+        periodId: period.periodId,
+        label: period.label ?? "",
+        startTime: normalizeTimeForApi(period.startTime),
+        endTime: normalizeTimeForApi(period.endTime),
+        taskContent: period.taskContent ?? "",
+        sortOrder: period.sortOrder ?? index + 1,
+        type: period.type ?? "STUDY",
+        status: period.status ?? "PENDING",
+    }));
+}
+
+function buildSavePayloadPeriods(periods = []) {
+    return sortPeriodsByTime(periods).map((period, index) => ({
+        label: period.label.trim(),
+        startTime: normalizeTimeForApi(period.startTime),
+        endTime: normalizeTimeForApi(period.endTime),
+        taskContent: period.taskContent?.trim() ?? "",
+        sortOrder: index + 1,
+        type: period.type || "STUDY",
+    }));
+}
+
+export default function RoutinePage() {
+    const navigate = useNavigate();
+
+    const [todayDate] = useState(() => getTodayDateText());
+    const [routine, setRoutine] = useState(null);
+    const [formPeriods, setFormPeriods] = useState(() => cloneDefaultPeriods());
+
+    const [now, setNow] = useState(() => new Date());
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [submittingStatus, setSubmittingStatus] = useState(false);
+    const [isEditMode, setIsEditMode] = useState(false);
+    const [message, setMessage] = useState("");
+
+    const orderedPeriods = useMemo(
+        () => sortPeriodsByTime(routine?.periods ?? []),
+        [routine]
+    );
+
+    const currentPeriod = useMemo(
+        () => findCurrentPeriod(orderedPeriods, now),
+        [orderedPeriods, now]
+    );
+
+    const nextPeriod = useMemo(
+        () => findNextPeriod(orderedPeriods, now),
+        [orderedPeriods, now]
+    );
+
+    const previousStudyPeriod = useMemo(
+        () => findPreviousStudyPeriod(orderedPeriods, currentPeriod),
+        [orderedPeriods, currentPeriod]
+    );
+
+    const isBreakTime = currentPeriod?.type === "BREAK";
+
+    const clockTitle = useMemo(() => {
+        if (currentPeriod && isBreakTime) {
+            if (previousStudyPeriod?.label) {
+                return `${previousStudyPeriod.label} 쉬는시간!`;
+            }
+
+            return "쉬는시간!";
+        }
+
+        if (currentPeriod) {
+            return currentPeriod.label;
+        }
+
+        if (nextPeriod) {
+            return "다음 루틴 대기";
+        }
+
+        return "오늘 루틴 종료";
+    }, [currentPeriod, isBreakTime, nextPeriod, previousStudyPeriod]);
+
+    const clockSeconds = useMemo(() => {
+        if (currentPeriod) {
+            return getElapsedSeconds(currentPeriod, now);
+        }
+
+        if (nextPeriod) {
+            return getRemainingSecondsUntilPeriod(nextPeriod, now);
+        }
+
+        return 0;
+    }, [currentPeriod, nextPeriod, now]);
+
+    const clockTaskText = useMemo(() => {
+        if (currentPeriod) {
+            return currentPeriod.taskContent?.trim() || "할 일이 비어 있습니다.";
+        }
+
+        if (nextPeriod) {
+            return `${nextPeriod.label} · ${formatTimeRange(nextPeriod)} · ${
+                nextPeriod.taskContent?.trim() || "할 일이 비어 있습니다."
+            }`;
+        }
+
+        return "오늘 등록된 모든 루틴 시간이 끝났습니다.";
+    }, [currentPeriod, nextPeriod]);
+
+    useEffect(() => {
+        const timerId = window.setInterval(() => {
+            setNow(new Date());
+        }, 1000);
+
+        return () => window.clearInterval(timerId);
+    }, []);
+
+    useEffect(() => {
+        let ignore = false;
+
+        async function loadRoutine() {
+            try {
+                setLoading(true);
+                setMessage("");
+
+                const data = await getDailyRoutine(todayDate);
+
+                if (ignore) return;
+
+                setRoutine(data);
+                setFormPeriods(toFormPeriods(data.periods));
+                setIsEditMode(false);
+            } catch (error) {
+                if (ignore) return;
+
+                console.error("오늘 루틴 조회 실패:", error);
+
+                setRoutine(null);
+                setFormPeriods(cloneDefaultPeriods());
+                setIsEditMode(true);
+                setMessage("오늘 등록된 루틴이 없습니다. 기본 루틴을 수정해서 저장해주세요.");
+            } finally {
+                if (!ignore) {
+                    setLoading(false);
+                }
+            }
+        }
+
+        loadRoutine();
+
+        return () => {
+            ignore = true;
+        };
+    }, [todayDate]);
+
+    function handleChangePeriod(index, field, value) {
+        setFormPeriods((prev) =>
+            prev.map((period, periodIndex) =>
+                periodIndex === index
+                    ? {
+                        ...period,
+                        [field]: value,
+                    }
+                    : period
+            )
+        );
+    }
+
+    function handleAddPeriod() {
+        setFormPeriods((prev) => {
+            const sortedPeriods = sortPeriodsByTime(prev);
+            const lastPeriod = sortedPeriods[sortedPeriods.length - 1];
+
+            const nextStartTime = lastPeriod?.endTime ?? "06:00:00";
+            const nextEndTime = addMinutesToTime(nextStartTime, 50);
+
+            return [
+                ...prev,
+                {
+                    label: `새 구간 ${prev.length + 1}`,
+                    startTime: nextStartTime,
+                    endTime: nextEndTime,
+                    taskContent: "",
+                    sortOrder: prev.length + 1,
+                    type: "STUDY",
+                },
+            ];
+        });
+    }
+
+    function handleRemovePeriod(index) {
+        if (formPeriods.length <= 1) {
+            alert("루틴 구간은 최소 1개 이상이어야 합니다.");
+            return;
+        }
+
+        setFormPeriods((prev) => prev.filter((_, periodIndex) => periodIndex !== index));
+    }
+
+    function handleLoadDefaultPeriods() {
+        const confirmed = window.confirm(
+            "현재 입력 중인 루틴을 기본 루틴으로 바꿀까요?"
+        );
+
+        if (!confirmed) return;
+
+        setFormPeriods(cloneDefaultPeriods());
+    }
+
+    function handleSortPeriods() {
+        setFormPeriods((prev) =>
+            sortPeriodsByTime(prev).map((period, index) => ({
+                ...period,
+                sortOrder: index + 1,
+            }))
+        );
+    }
+
+    function handleStartEdit() {
+        if (routine?.periods?.length) {
+            setFormPeriods(toFormPeriods(routine.periods));
+        } else {
+            setFormPeriods(cloneDefaultPeriods());
+        }
+
+        setIsEditMode(true);
+    }
+
+    function handleCancelEdit() {
+        if (!routine) {
+            navigate("/");
+            return;
+        }
+
+        setFormPeriods(toFormPeriods(routine.periods));
+        setIsEditMode(false);
+    }
+
+    async function handleSaveRoutine() {
+        const payloadPeriods = buildSavePayloadPeriods(formPeriods);
+        const validationMessage = validatePeriods(payloadPeriods);
+
+        if (validationMessage) {
+            alert(validationMessage);
+            return;
+        }
+
+        try {
+            setSaving(true);
+            setMessage("");
+
+            const savedRoutine = await saveDailyRoutine({
+                routineDate: todayDate,
+                periods: payloadPeriods,
+            });
+
+            setRoutine(savedRoutine);
+            setFormPeriods(toFormPeriods(savedRoutine.periods));
+            setIsEditMode(false);
+            setMessage("오늘 루틴이 저장되었습니다.");
+        } catch (error) {
+            console.error("오늘 루틴 저장 실패:", error);
+            alert(getApiErrorMessage(error, "오늘 루틴 저장에 실패했습니다."));
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    async function handleCompleteCurrentPeriod() {
+        if (!currentPeriod?.periodId) {
+            alert("저장된 루틴 구간만 완료 처리할 수 있습니다.");
+            return;
+        }
+
+        try {
+            setSubmittingStatus(true);
+
+            const updatedRoutine = await completeRoutinePeriod(currentPeriod.periodId);
+
+            setRoutine(updatedRoutine);
+            setFormPeriods(toFormPeriods(updatedRoutine.periods));
+        } catch (error) {
+            console.error("루틴 완료 처리 실패:", error);
+            alert(getApiErrorMessage(error, "루틴 완료 처리에 실패했습니다."));
+        } finally {
+            setSubmittingStatus(false);
+        }
+    }
+
+    async function handleTogglePeriodCompleted(period) {
+        if (!period?.periodId) {
+            alert("저장된 루틴 구간만 상태를 변경할 수 있습니다.");
+            return;
+        }
+
+        try {
+            setSubmittingStatus(true);
+
+            const updatedRoutine =
+                period.status === "COMPLETED"
+                    ? await resetRoutinePeriod(period.periodId)
+                    : await completeRoutinePeriod(period.periodId);
+
+            setRoutine(updatedRoutine);
+            setFormPeriods(toFormPeriods(updatedRoutine.periods));
+        } catch (error) {
+            console.error("루틴 상태 변경 실패:", error);
+            alert(getApiErrorMessage(error, "루틴 상태 변경에 실패했습니다."));
+        } finally {
+            setSubmittingStatus(false);
+        }
+    }
+
+    async function handleSkipCurrentPeriod() {
+        if (!currentPeriod?.periodId) {
+            alert("저장된 루틴 구간만 건너뜀 처리할 수 있습니다.");
+            return;
+        }
+
+        try {
+            setSubmittingStatus(true);
+
+            const updatedRoutine = await skipRoutinePeriod(currentPeriod.periodId);
+
+            setRoutine(updatedRoutine);
+            setFormPeriods(toFormPeriods(updatedRoutine.periods));
+        } catch (error) {
+            console.error("루틴 건너뜀 처리 실패:", error);
+            alert(getApiErrorMessage(error, "루틴 건너뜀 처리에 실패했습니다."));
+        } finally {
+            setSubmittingStatus(false);
+        }
+    }
+
+    if (loading) {
+        return (
+            <div style={pageStyle}>
+                <h1 style={{ margin: 0 }}>오늘 루틴 시계</h1>
+                <p style={mutedTextStyle}>오늘 루틴을 불러오는 중입니다...</p>
+            </div>
+        );
+    }
+
+    return (
+        <div style={pageStyle}>
+            <header
+                style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: 12,
+                    marginBottom: 14,
+                }}
+            >
+                <div>
+                    <h1
+                        style={{
+                            margin: 0,
+                            fontSize: 28,
+                            letterSpacing: "-0.05em",
+                        }}
+                    >
+                        오늘 루틴 시계
+                    </h1>
+                    <p
+                        style={{
+                            ...mutedTextStyle,
+                            marginTop: 6,
+                            marginBottom: 0,
+                            fontSize: 13,
+                        }}
+                    >
+                        {todayDate} · 현재 시간 기준으로 교시와 할 일을 자동 표시합니다.
+                    </p>
+                </div>
+
+                <div
+                    style={{
+                        display: "flex",
+                        gap: 8,
+                        flexWrap: "wrap",
+                        justifyContent: "flex-end",
+                    }}
+                >
+                    <button
+                        type="button"
+                        onClick={() => navigate("/")}
+                        style={buttonBaseStyle}
+                    >
+                        홈
+                    </button>
+
+                    {!isEditMode && (
+                        <button
+                            type="button"
+                            onClick={handleStartEdit}
+                            style={primaryButtonStyle}
+                        >
+                            루틴 수정
+                        </button>
+                    )}
+                </div>
+            </header>
+
+            {message && (
+                <div
+                    style={{
+                        ...softCardStyle,
+                        marginBottom: 12,
+                        color: "var(--color-primary)",
+                        fontSize: 14,
+                        fontWeight: 700,
+                    }}
+                >
+                    {message}
+                </div>
+            )}
+
+            {isEditMode ? (
+                <section style={cardStyle}>
+                    <div
+                        style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "flex-start",
+                            gap: 12,
+                            marginBottom: 16,
+                            flexWrap: "wrap",
+                        }}
+                    >
+                        <div>
+                            <h2
+                                style={{
+                                    margin: 0,
+                                    fontSize: 21,
+                                    letterSpacing: "-0.04em",
+                                }}
+                            >
+                                오늘 루틴 등록/수정
+                            </h2>
+                            <p
+                                style={{
+                                    ...mutedTextStyle,
+                                    marginTop: 6,
+                                    marginBottom: 0,
+                                    fontSize: 13,
+                                    lineHeight: 1.5,
+                                }}
+                            >
+                                교시명은 화면 표시용이고, 실제 루틴 판단은 시작 시간과 종료 시간으로 계산합니다.
+                            </p>
+                        </div>
+
+                        <div
+                            style={{
+                                display: "flex",
+                                gap: 8,
+                                flexWrap: "wrap",
+                                justifyContent: "flex-end",
+                            }}
+                        >
+                            <button
+                                type="button"
+                                onClick={handleLoadDefaultPeriods}
+                                style={buttonBaseStyle}
+                            >
+                                기본값
+                            </button>
+
+                            <button
+                                type="button"
+                                onClick={handleSortPeriods}
+                                style={buttonBaseStyle}
+                            >
+                                시간순 정렬
+                            </button>
+
+                            <button
+                                type="button"
+                                onClick={handleAddPeriod}
+                                style={primaryButtonStyle}
+                            >
+                                + 구간 추가
+                            </button>
+                        </div>
+                    </div>
+
+                    <div
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 12,
+                        }}
+                    >
+                        {formPeriods.map((period, index) => (
+                            <div
+                                key={`${period.label}-${period.startTime}-${index}`}
+                                style={{
+                                    ...softCardStyle,
+                                    ...getPeriodCardVisualStyle(period, false),
+                                    display: "grid",
+                                    gridTemplateColumns: "minmax(110px, 0.8fr) 112px 112px 118px minmax(220px, 2fr) auto",                                    gap: 8,
+                                    alignItems: "center",
+                                }}
+                            >
+                                <label
+                                    style={{
+                                        display: "flex",
+                                        flexDirection: "column",
+                                        gap: 5,
+                                        fontSize: 12,
+                                        color: "var(--color-text-muted)",
+                                        minWidth: 0,
+                                    }}
+                                >
+                                    구간명
+                                    <input
+                                        value={period.label}
+                                        onChange={(event) =>
+                                            handleChangePeriod(index, "label", event.target.value)
+                                        }
+                                        placeholder="1교시"
+                                        style={inputStyle}
+                                    />
+                                </label>
+
+                                <label
+                                    style={{
+                                        display: "flex",
+                                        flexDirection: "column",
+                                        gap: 5,
+                                        fontSize: 12,
+                                        color: "var(--color-text-muted)",
+                                    }}
+                                >
+                                    시작
+                                    <input
+                                        type="text"
+                                        inputMode="numeric"
+                                        value={toTimeInputValue(period.startTime)}
+                                        onChange={(event) =>
+                                            handleChangePeriod(index, "startTime", event.target.value)
+                                        }
+                                        onBlur={(event) =>
+                                            handleChangePeriod(
+                                                index,
+                                                "startTime",
+                                                normalizeTimeInputText(event.target.value)
+                                            )
+                                        }
+                                        placeholder="06:00"
+                                        style={{
+                                            ...inputStyle,
+                                            fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                                            fontWeight: 800,
+                                            letterSpacing: "-0.03em",
+                                            textAlign: "center",
+                                        }}
+                                    />
+                                </label>
+
+                                <label
+                                    style={{
+                                        display: "flex",
+                                        flexDirection: "column",
+                                        gap: 5,
+                                        fontSize: 12,
+                                        color: "var(--color-text-muted)",
+                                    }}
+                                >
+                                    종료
+                                    <input
+                                        type="text"
+                                        inputMode="numeric"
+                                        value={toTimeInputValue(period.endTime)}
+                                        onChange={(event) =>
+                                            handleChangePeriod(index, "endTime", event.target.value)
+                                        }
+                                        onBlur={(event) =>
+                                            handleChangePeriod(
+                                                index,
+                                                "endTime",
+                                                normalizeTimeInputText(event.target.value)
+                                            )
+                                        }
+                                        placeholder="06:50"
+                                        style={{
+                                            ...inputStyle,
+                                            fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                                            fontWeight: 800,
+                                            letterSpacing: "-0.03em",
+                                            textAlign: "center",
+                                        }}
+                                    />
+                                </label>
+
+                                <label
+                                    style={{
+                                        display: "flex",
+                                        flexDirection: "column",
+                                        gap: 5,
+                                        fontSize: 12,
+                                        color: "var(--color-text-muted)",
+                                    }}
+                                >
+                                    타입
+                                    <select
+                                        value={period.type}
+                                        onChange={(event) =>
+                                            handleChangePeriod(index, "type", event.target.value)
+                                        }
+                                        style={inputStyle}
+                                    >
+                                        <option value="STUDY">공부</option>
+                                        <option value="BREAK">쉬는시간</option>
+                                        <option value="ETC">기타</option>
+                                    </select>
+                                </label>
+
+                                <label
+                                    style={{
+                                        display: "flex",
+                                        flexDirection: "column",
+                                        gap: 5,
+                                        fontSize: 12,
+                                        color: "var(--color-text-muted)",
+                                        minWidth: 0,
+                                    }}
+                                >
+                                    할 일
+                                    <textarea
+                                        value={period.taskContent}
+                                        onChange={(event) =>
+                                            handleChangePeriod(index, "taskContent", event.target.value)
+                                        }
+                                        placeholder="이 시간에 할 일을 적어주세요"
+                                        rows={1}
+                                        style={textareaStyle}
+                                    />
+                                </label>
+
+                                <button
+                                    type="button"
+                                    onClick={() => handleRemovePeriod(index)}
+                                    style={{
+                                        ...dangerButtonStyle,
+                                        alignSelf: "end",
+                                        padding: "9px 10px",
+                                    }}
+                                >
+                                    삭제
+                                </button>
+                            </div>
+                        ))}
+                    </div>
+
+                    <div
+                        style={{
+                            display: "flex",
+                            gap: 8,
+                            marginTop: 16,
+                            flexWrap: "wrap",
+                        }}
+                    >
+                        <button
+                            type="button"
+                            onClick={handleSaveRoutine}
+                            disabled={saving}
+                            style={{
+                                ...primaryButtonStyle,
+                                flex: 1,
+                                opacity: saving ? 0.65 : 1,
+                                cursor: saving ? "not-allowed" : "pointer",
+                            }}
+                        >
+                            {saving ? "저장 중..." : "오늘 루틴 저장"}
+                        </button>
+
+                        <button
+                            type="button"
+                            onClick={handleCancelEdit}
+                            disabled={saving}
+                            style={buttonBaseStyle}
+                        >
+                            취소
+                        </button>
+                    </div>
+                </section>
+            ) : (
+                <>
+                    <section
+                        style={{
+                            minHeight: "min(70vh, 620px)",
+                            borderRadius: 24,
+                            border: isBreakTime
+                                ? "1px solid #e5e7eb"
+                                : "1px solid #111827",
+                            background: isBreakTime ? "#ffffff" : "#000000",
+                            color: isBreakTime ? "#111827" : "#ffffff",
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            textAlign: "center",
+                            padding: "clamp(28px, 8vw, 72px) clamp(14px, 5vw, 48px)",
+                            boxSizing: "border-box",
+                            boxShadow: "0 18px 55px rgba(0, 0, 0, 0.35)",
+                        }}
+                    >
+                        <div
+                            style={{
+                                color: isBreakTime ? "#111827" : "#facc15",
+                                fontSize: "clamp(38px, 11vw, 86px)",
+                                fontWeight: 900,
+                                lineHeight: 1.05,
+                                letterSpacing: "-0.08em",
+                                marginBottom: "clamp(20px, 4vw, 28px)",
+                            }}
+                        >
+                            {clockTitle}
+                        </div>
+
+                        <div
+                            style={{
+                                color: isBreakTime ? "#111827" : "#ffffff",
+                                fontFamily:
+                                    "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+                                fontSize: "clamp(52px, 16vw, 132px)",
+                                fontWeight: 900,
+                                lineHeight: 1,
+                                letterSpacing: "-0.08em",
+                                marginBottom: "clamp(28px, 5vw, 46px)",
+                            }}
+                        >
+                            {formatClockTime(clockSeconds)}
+                        </div>
+
+                        <div
+                            style={{
+                                color: isBreakTime ? "#111827" : "#fb7185",
+                                fontSize: "clamp(22px, 6vw, 48px)",
+                                fontWeight: 800,
+                                lineHeight: 1.35,
+                                letterSpacing: "-0.06em",
+                                maxWidth: 900,
+                                wordBreak: "keep-all",
+                                overflowWrap: "break-word",
+                            }}
+                        >
+                            {clockTaskText}
+                        </div>
+
+                        {currentPeriod && (
+                            <div
+                                style={{
+                                    display: "flex",
+                                    gap: 8,
+                                    justifyContent: "center",
+                                    flexWrap: "wrap",
+                                    marginTop: 28,
+                                    fontSize: 14,
+                                    fontWeight: 800,
+                                }}
+                            >
+                                <span
+                                    style={{
+                                        border: isBreakTime
+                                            ? "1px solid #111827"
+                                            : "1px solid #374151",
+                                        borderRadius: 999,
+                                        padding: "7px 12px",
+                                        color: isBreakTime ? "#111827" : "#d1d5db",
+                                    }}
+                                >
+                                    {formatTimeRange(currentPeriod)}
+                                </span>
+
+                                <span
+                                    style={{
+                                        border: isBreakTime
+                                            ? "1px solid #111827"
+                                            : "1px solid #374151",
+                                        borderRadius: 999,
+                                        padding: "7px 12px",
+                                        color: isBreakTime ? "#111827" : "#d1d5db",
+                                    }}
+                                >
+                                    {getStatusText(currentPeriod.status)}
+                                </span>
+                            </div>
+                        )}
+
+                    </section>
+
+                    <section
+                        style={{
+                            ...cardStyle,
+                            marginTop: 14,
+                        }}
+                    >
+                        <div
+                            style={{
+                                display: "flex",
+                                justifyContent: "space-between",
+                                alignItems: "center",
+                                gap: 12,
+                                marginBottom: 12,
+                            }}
+                        >
+                            <h2
+                                style={{
+                                    margin: 0,
+                                    fontSize: 18,
+                                    letterSpacing: "-0.04em",
+                                }}
+                            >
+                                오늘 루틴 목록
+                            </h2>
+
+                            <span
+                                style={{
+                                    ...mutedTextStyle,
+                                    fontSize: 13,
+                                }}
+                            >
+                                {orderedPeriods.length}개 구간
+                            </span>
+                        </div>
+
+                        <div
+                            style={{
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: 8,
+                            }}
+                        >
+                            {orderedPeriods.map((period) => {
+                                const active = isSamePeriod(period, currentPeriod);
+
+                                return (
+                                    <div
+                                        key={period.periodId ?? `${period.label}-${period.startTime}`}
+                                        style={{
+                                            display: "grid",
+                                            gridTemplateColumns: "88px 116px minmax(0, 1fr) auto",
+                                            gap: 8,
+                                            alignItems: "center",
+                                            border: "1px solid var(--color-border)",
+                                            borderRadius: 12,
+                                            padding: "10px 12px",
+                                            ...getPeriodCardVisualStyle(period, active),
+                                        }}
+                                    >
+                                        <strong
+                                            style={{
+                                                color: active
+                                                    ? "var(--color-primary)"
+                                                    : "var(--color-text)",
+                                                fontSize: 14,
+                                                whiteSpace: "nowrap",
+                                            }}
+                                        >
+                                            {period.label}
+                                        </strong>
+
+                                        <span
+                                            style={{
+                                                ...mutedTextStyle,
+                                                fontSize: 13,
+                                                whiteSpace: "nowrap",
+                                            }}
+                                        >
+                                            {formatTimeRange(period)}
+                                        </span>
+
+                                        <span
+                                            style={{
+                                                fontSize: 14,
+                                                overflow: "hidden",
+                                                textOverflow: "ellipsis",
+                                                whiteSpace: "nowrap",
+                                            }}
+                                        >
+                                            {period.taskContent || "할 일 없음"}
+                                        </span>
+
+                                        <button
+                                            type="button"
+                                            onClick={() => handleTogglePeriodCompleted(period)}
+                                            disabled={submittingStatus}
+                                            style={{
+                                                ...getPeriodStatusButtonStyle(period),
+                                                opacity: submittingStatus ? 0.65 : 1,
+                                                cursor: submittingStatus ? "not-allowed" : "pointer",
+                                            }}
+                                        >
+                                            {period.status === "COMPLETED" ? "완료" : "대기"}
+                                        </button>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </section>
+                </>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/pages/routine/routineTimeUtils.js
+++ b/frontend/src/pages/routine/routineTimeUtils.js
@@ -1,0 +1,78 @@
+export function getTodayDateText() {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const date = String(now.getDate()).padStart(2, "0");
+
+    return `${year}-${month}-${date}`;
+}
+
+export function parseTodayTime(timeText, baseDate = new Date()) {
+    const [hour, minute, second = "0"] = String(timeText).split(":");
+
+    const date = new Date(baseDate);
+    date.setHours(Number(hour), Number(minute), Number(second), 0);
+
+    return date;
+}
+
+export function findCurrentPeriod(periods = [], now = new Date()) {
+    return periods.find((period) => {
+        const start = parseTodayTime(period.startTime, now);
+        const end = parseTodayTime(period.endTime, now);
+
+        return start <= now && now < end;
+    }) ?? null;
+}
+
+export function findNextPeriod(periods = [], now = new Date()) {
+    return periods.find((period) => {
+        const start = parseTodayTime(period.startTime, now);
+
+        return now < start;
+    }) ?? null;
+}
+
+export function getElapsedSeconds(period, now = new Date()) {
+    if (!period) {
+        return 0;
+    }
+
+    const start = parseTodayTime(period.startTime, now);
+
+    return Math.max(0, Math.floor((now - start) / 1000));
+}
+
+export function getRemainingSeconds(period, now = new Date()) {
+    if (!period) {
+        return 0;
+    }
+
+    const end = parseTodayTime(period.endTime, now);
+
+    return Math.max(0, Math.floor((end - now) / 1000));
+}
+
+export function formatClockTime(totalSeconds) {
+    const safeSeconds = Math.max(0, Number(totalSeconds) || 0);
+
+    const hours = Math.floor(safeSeconds / 3600);
+    const minutes = Math.floor((safeSeconds % 3600) / 60);
+    const seconds = safeSeconds % 60;
+
+    return [
+        String(hours).padStart(2, "0"),
+        String(minutes).padStart(2, "0"),
+        String(seconds).padStart(2, "0"),
+    ].join(":");
+}
+
+export function sortPeriodsByTime(periods = []) {
+    return [...periods].sort((a, b) => {
+        if (a.startTime === b.startTime) {
+            return Number(a.sortOrder ?? 0) - Number(b.sortOrder ?? 0);
+        }
+
+        return String(a.startTime).localeCompare(String(b.startTime));
+    });
+}

--- a/frontend/src/shared/api/routineApi.js
+++ b/frontend/src/shared/api/routineApi.js
@@ -1,0 +1,39 @@
+import { apiClient } from "./client";
+
+export async function getDailyRoutine(date) {
+    const response = await apiClient.get("/api/v1/routines/daily", {
+        params: { date },
+    });
+
+    return response.data.result;
+}
+
+export async function saveDailyRoutine(payload) {
+    const response = await apiClient.put("/api/v1/routines/daily", payload);
+
+    return response.data.result;
+}
+
+export async function completeRoutinePeriod(periodId) {
+    const response = await apiClient.patch(
+        `/api/v1/routines/periods/${periodId}/complete`
+    );
+
+    return response.data.result;
+}
+
+export async function skipRoutinePeriod(periodId) {
+    const response = await apiClient.patch(
+        `/api/v1/routines/periods/${periodId}/skip`
+    );
+
+    return response.data.result;
+}
+
+export async function resetRoutinePeriod(periodId) {
+    const response = await apiClient.patch(
+        `/api/v1/routines/periods/${periodId}/pending`
+    );
+
+    return response.data.result;
+}


### PR DESCRIPTION
## 📝 작업 내용 설명

현재 사용자는 하루 공부 계획을 노션 시간표 형태로 관리하고 있지만, 실제 공부 중에는 현재 시간이 몇 교시에 해당하는지, 해당 교시가 시작된 지 몇 분 몇 초가 지났는지, 지금 해야 할 일이 무엇인지 즉시 확인하기 어렵다.

기존에는 루틴 시계 영상을 옆에 틀어두는 방식으로 보완했지만, 휴대폰으로 다른 작업을 하거나 중간에 다시 페이지를 확인할 때 현재 교시 진행 시간을 정확히 알기 어렵다는 문제가 있었다.

이번 PR에서는 사용자가 오늘 루틴을 등록하면, 현재 시간 기준으로 현재 교시/경과 시간/할 일을 실시간으로 보여주는 `오늘 루틴 시계 MVP`를 구현했다.

루틴은 고정된 교시 enum에 의존하지 않고, 사용자가 등록한 `startTime`, `endTime` 기준으로 현재 구간을 계산하도록 설계했다. 이를 통해 루틴 시간이 변경되거나 쉬는 시간이 추가되어도 유연하게 대응할 수 있다.

## ✅ 작업 내용

* [x] 오늘 루틴 저장을 위한 백엔드 도메인 구조 추가

  * `DailyRoutine`
  * `RoutinePeriod`
  * `RoutinePeriodType`
  * `RoutinePeriodStatus`

* [x] 오늘 루틴 생성/조회 API 구현

  * 특정 날짜의 루틴 저장
  * 특정 날짜의 루틴 조회
  * 기존 날짜 루틴이 존재할 경우 새 요청값으로 교체

* [x] 루틴 시간 구간 유효성 검증 구현

  * 시작 시간이 종료 시간보다 늦거나 같은 경우 예외 처리
  * 시간 구간이 서로 겹치는 경우 예외 처리

* [x] 루틴 구간 상태 변경 API 구현

  * 완료 처리
  * 대기 상태 복구 처리

* [x] 루틴 API Swagger 문서 추가

  * API별 `summary`, `description` 작성

* [x] 프론트엔드 루틴 API 연동 함수 추가

  * 오늘 루틴 조회
  * 오늘 루틴 저장/수정
  * 루틴 구간 완료 처리
  * 루틴 구간 대기 상태 복구

* [x] 오늘 루틴 등록/수정 화면 구현

  * 교시명/구간명 입력
  * 시작 시간 입력
  * 종료 시간 입력
  * 구간 타입 선택
  * 할 일 입력
  * 구간 추가/삭제
  * 기본 루틴 불러오기
  * 시간순 정렬

* [x] 현재 시간 기준 루틴 시계 화면 구현

  * 현재 구간명 표시
  * 해당 구간 시작 후 경과 시간 1초 단위 표시
  * 현재 해야 할 일 표시
  * 현재 구간이 없을 경우 다음 예정 구간 또는 루틴 종료 상태 표시

* [x] 루틴 목록 상태 토글 구현

  * 각 공부/기타 구간의 `대기/완료` 상태를 목록에서 직접 토글
  * 쉬는 시간 구간은 완료 대상에서 제외
  * 완료된 구간은 시각적으로 구분

* [x] 이전 미완료 할 일 표시 구현

  * 현재 시간 이전에 완료하지 못한 작업이 있으면 시계 화면의 할 일 영역에 함께 표시
  * 쉬는 시간에도 이전 미완료 작업을 확인할 수 있도록 처리

* [x] 홈 화면에서 루틴 시계 진입 버튼 추가

## 🔍 주요 변경 포인트

### 1. 고정 교시가 아닌 시간 기반 루틴 구조

`1교시 = 06:00~06:50`처럼 서버 코드에 시간을 고정하지 않고, 사용자가 등록한 시간 구간의 `startTime`, `endTime`을 기준으로 현재 구간을 판단한다.

이를 통해 다음과 같은 변경에도 대응할 수 있다.

* 1교시 시간이 변경되는 경우
* 쉬는 시간이 추가되는 경우
* 야자 교시가 줄거나 늘어나는 경우
* 특정 날짜에만 다른 루틴을 사용하는 경우

### 2. 교시명과 시간 계산 기준 분리

`1교시`, `야자 1교시`, `쉬는 시간` 같은 값은 화면 표시용 `label`로 사용한다.

실제 현재 구간 계산은 label이 아니라 시간 범위로 처리한다.

```text
startTime <= 현재 시각 < endTime
```

### 3. 프론트에서 실시간 계산

백엔드는 오늘 루틴 데이터를 내려주고, 프론트는 현재 시각 기준으로 현재 구간과 경과 시간을 계산한다.

따라서 루틴 시계는 1초마다 API를 호출하지 않고, `setInterval`로 화면 시간만 갱신한다.

### 4. 루틴 수정에 유연한 입력 화면 구성

오늘 루틴 등록/수정 화면에서 사용자가 직접 구간명, 시작 시간, 종료 시간, 타입, 할 일을 수정할 수 있도록 구성했다.

또한 기본 루틴을 빠르게 불러오고, 필요 시 구간을 추가/삭제할 수 있도록 했다.

### 5. 현재 작업뿐 아니라 밀린 작업도 확인 가능

현재 구간의 할 일만 보여주는 것이 아니라, 현재 시간 이전에 완료하지 못한 작업이 있다면 함께 표시한다.

이를 통해 할 일이 밀리더라도 사용자가 이전 작업을 놓치지 않고 확인할 수 있다.

## 🧪 확인한 내용

* [x] 오늘 루틴 저장 API 정상 동작 확인
* [x] 오늘 루틴 조회 API 정상 동작 확인
* [x] 루틴 구간 완료 처리 API 정상 동작 확인
* [x] 루틴 구간 대기 상태 복구 API 정상 동작 확인
* [x] 시작 시간이 종료 시간보다 늦거나 같은 경우 저장되지 않는지 확인
* [x] 시간 구간이 겹치는 경우 저장되지 않는지 확인
* [x] 페이지 진입 시 오늘 루틴이 조회되는지 확인
* [x] 등록된 루틴이 없을 경우 기본 루틴 등록 화면이 표시되는지 확인
* [x] 루틴 저장 후 현재 시간 기준 시계 화면이 표시되는지 확인
* [x] 1초 단위로 경과 시간이 갱신되는지 확인
* [x] 현재 시간이 다음 구간으로 넘어가면 표시 내용이 변경되는지 확인
* [x] 오늘 루틴 목록에서 대기/완료 상태 토글이 동작하는지 확인
* [x] 쉬는 시간 구간에는 대기/완료 버튼이 표시되지 않는지 확인
* [x] 이전 미완료 작업이 시계 화면에 함께 표시되는지 확인
* [x] 홈 화면에서 루틴 시계 페이지로 이동되는지 확인

## 📌 비고

이번 PR은 `오늘 루틴 시계 MVP` 구현에 집중한다.

다음 기능들은 이번 PR 범위에서 제외했다.

* AI 멘토 피드백
* 하루 성찰/회고 생성
* 보호자에게 카카오톡 또는 문자 자동 전송
* 루틴 통계
* 반복 루틴 템플릿
* 어제 루틴 복사
* 문제풀이 기능과 직접 연결

다만 추후 확장을 고려해 루틴 구간별 상태값은 저장할 수 있도록 설계했다.

현재 루틴 API 접근 권한은 개발 및 Swagger 테스트 편의를 위해 임시로 허용한 상태이며, 프론트 연동 및 인증 흐름 정리 후 로그인 사용자 기준으로 보호하는 작업이 필요하다.

## 🔗 관련 이슈

closes #79
