### PR TITLE
feat(mentor): AI 데일리 멘토 피드백 MVP 구현

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -79,5 +79,11 @@ jobs:
               -e GITHUB_DAILY_BASE_PATH='daily' \
               -e GITHUB_DAILY_COMMITTER_NAME='hhd1337' \
               -e GITHUB_DAILY_COMMITTER_EMAIL='goeka1337@gmail.com' \
+              -e OPENAI_API_KEY='${{ secrets.OPENAI_API_KEY }}' \
+              -e OPENAI_MODEL='${{ secrets.OPENAI_MODEL }}' \
+              -e OPENAI_BASE_URL='https://api.openai.com/v1' \
+              -e OPENAI_TIMEOUT_SECONDS='30' \
+              -e OPENAI_MAX_OUTPUT_TOKENS='1200' \
+              -e MENTOR_FEEDBACK_PROVIDER='openai' \
               ${{ env.IMAGE_NAME }}
             docker image prune -f

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/config/SecurityConfig.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/config/SecurityConfig.java
@@ -90,7 +90,7 @@ public class SecurityConfig {
                          * Swagger에서 PUT/PATCH/POST/DELETE 요청을 직접 테스트할 때는
                          * CSRF 토큰이 자동으로 포함되지 않아 403이 발생할 수 있다.
                          *
-                         * /api/v1/routines/** 는 현재 루틴 시계 MVP 개발/검증 단계에서만 임시로 제외한다.
+                         * /api/v1/routines/**, /api/v1/mentor/** 는 현재 MVP 개발/검증 단계에서만 임시로 제외한다.
                          * 프론트 연동 후에는 CSRF 토큰을 정상 전송하도록 바꾸고,
                          * 이 예외는 제거하는 것이 좋다.
                          */
@@ -103,7 +103,8 @@ public class SecurityConfig {
                                 "/api/v1/test/github-daily-upload",
 
                                 // TODO: 개발 단계 Swagger 테스트용 임시 허용
-                                "/api/v1/routines/**"
+                                "/api/v1/routines/**",
+                                "/api/v1/mentor/**"
                         )
                 )
 

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/config/OpenAiProperties.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/config/OpenAiProperties.java
@@ -1,0 +1,32 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "openai")
+public class OpenAiProperties {
+
+    private String apiKey;
+
+    private String model = "gpt-5.5";
+
+    private String baseUrl = "https://api.openai.com/v1";
+
+    private long timeoutSeconds = 30;
+
+    private int maxOutputTokens = 3000;
+
+    public String getNormalizedBaseUrl() {
+        if (!StringUtils.hasText(baseUrl)) {
+            return "https://api.openai.com/v1";
+        }
+
+        return baseUrl.replaceAll("/+$", "");
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/controller/DailyMentorFeedbackController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/controller/DailyMentorFeedbackController.java
@@ -1,0 +1,50 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.controller;
+
+import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorResponse;
+import com.hhd1337.jatuli_quiz.domain.mentor.service.DailyMentorFeedbackService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "Daily AI Mentor Feedback API",
+        description = "일일 AI 멘토 피드백 생성 및 조회 API"
+)
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mentor/feedbacks")
+public class DailyMentorFeedbackController {
+
+    private final DailyMentorFeedbackService dailyMentorFeedbackService;
+
+    @Operation(
+            summary = "일일 AI 멘토 피드백 생성",
+            description = "장기/월간/주간 계획, 오늘 루틴 결과, 오늘 소감, 시간 기록을 조합해 "
+                    + "AI 멘토 피드백을 생성하고 DB에 저장합니다. "
+                    + "같은 날짜의 피드백이 이미 있으면 새로 생성한 내용으로 갱신합니다."
+    )
+    @PostMapping("/daily")
+    public ApiResponse<MentorResponse.DailyMentorFeedbackResponse> generateDailyFeedback(
+            @RequestParam LocalDate date
+    ) {
+        return ApiResponse.onSuccess(dailyMentorFeedbackService.generateDailyFeedback(date));
+    }
+
+    @Operation(
+            summary = "일일 AI 멘토 피드백 조회",
+            description = "특정 날짜에 생성된 AI 멘토 피드백을 조회합니다."
+    )
+    @GetMapping("/daily")
+    public ApiResponse<MentorResponse.DailyMentorFeedbackResponse> getDailyFeedback(
+            @RequestParam LocalDate date
+    ) {
+        return ApiResponse.onSuccess(dailyMentorFeedbackService.getDailyFeedback(date));
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/controller/DailyReflectionController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/controller/DailyReflectionController.java
@@ -1,0 +1,51 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.controller;
+
+import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorRequest;
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorResponse;
+import com.hhd1337.jatuli_quiz.domain.mentor.service.DailyReflectionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "Daily Reflection API",
+        description = "하루 마무리 소감 저장 및 조회 API"
+)
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mentor/reflections")
+public class DailyReflectionController {
+
+    private final DailyReflectionService dailyReflectionService;
+
+    @Operation(
+            summary = "오늘 소감 저장/수정",
+            description = "특정 날짜의 오늘 컨디션, 잘한 점, 아쉬운 점, 자유 소감을 저장하거나 수정합니다. "
+                    + "저장 시 소감 작성 시각이 기록됩니다."
+    )
+    @PutMapping("/daily")
+    public ApiResponse<MentorResponse.DailyReflectionResponse> saveDailyReflection(
+            @RequestBody MentorRequest.SaveDailyReflectionRequest request
+    ) {
+        return ApiResponse.onSuccess(dailyReflectionService.saveDailyReflection(request));
+    }
+
+    @Operation(
+            summary = "오늘 소감 조회",
+            description = "특정 날짜에 작성한 하루 마무리 소감을 조회합니다."
+    )
+    @GetMapping("/daily")
+    public ApiResponse<MentorResponse.DailyReflectionResponse> getDailyReflection(
+            @RequestParam LocalDate date
+    ) {
+        return ApiResponse.onSuccess(dailyReflectionService.getDailyReflection(date));
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/controller/MentorPlanController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/controller/MentorPlanController.java
@@ -1,0 +1,50 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.controller;
+
+import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorRequest;
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorResponse;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.MentorPlanType;
+import com.hhd1337.jatuli_quiz.domain.mentor.service.MentorPlanService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "AI Mentor Plan API",
+        description = "AI 멘토 피드백에 사용할 장기/월간/주간 계획 저장 및 조회 API"
+)
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mentor/plans")
+public class MentorPlanController {
+
+    private final MentorPlanService mentorPlanService;
+
+    @Operation(
+            summary = "AI 멘토 계획 저장/수정",
+            description = "취업 전반 계획, 이번달 계획, 이번주 계획을 저장하거나 수정합니다. "
+                    + "type은 CAREER, MONTHLY, WEEKLY 중 하나입니다."
+    )
+    @PutMapping("/{type}")
+    public ApiResponse<MentorResponse.MentorPlanResponse> savePlan(
+            @PathVariable MentorPlanType type,
+            @RequestBody MentorRequest.SaveMentorPlanRequest request
+    ) {
+        return ApiResponse.onSuccess(mentorPlanService.savePlan(type, request));
+    }
+
+    @Operation(
+            summary = "현재 적용 중인 AI 멘토 계획 조회",
+            description = "현재 활성화된 취업 전반 계획, 이번달 계획, 이번주 계획을 조회합니다."
+    )
+    @GetMapping("/current")
+    public ApiResponse<MentorResponse.CurrentMentorPlansResponse> getCurrentPlans() {
+        return ApiResponse.onSuccess(mentorPlanService.getCurrentPlans());
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/controller/MentorRoutineSummaryController.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/controller/MentorRoutineSummaryController.java
@@ -1,0 +1,41 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.controller;
+
+import com.hhd1337.jatuli_quiz.common.response.ApiResponse;
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorResponse;
+import com.hhd1337.jatuli_quiz.domain.mentor.service.RoutineSummaryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "Mentor Routine Summary API",
+        description = "AI 멘토 피드백 및 프론트 요약 화면에 사용할 일일 루틴 결과 요약 API"
+)
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mentor/routine-summary")
+public class MentorRoutineSummaryController {
+
+    private final RoutineSummaryService routineSummaryService;
+
+    @Operation(
+            summary = "일일 루틴 결과 요약 조회",
+            description = "특정 날짜의 루틴 전체 구간 수, 완료 수, 미완료 수, 완료율, "
+                    + "완료한 일 목록, 미완료한 일 목록, 완료 처리 시각 정보를 요약해서 조회합니다."
+    )
+    @GetMapping("/daily")
+    public ApiResponse<MentorResponse.DailyRoutineSummaryResponse> getDailyRoutineSummary(
+            @RequestParam LocalDate date
+    ) {
+        return ApiResponse.onSuccess(
+                MentorResponse.DailyRoutineSummaryResponse.from(
+                        routineSummaryService.getDailyRoutineSummary(date)
+                )
+        );
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/dto/MentorDto.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/dto/MentorDto.java
@@ -1,0 +1,36 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.dto;
+
+import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriodStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+public class MentorDto {
+
+    public record DailyRoutineSummary(
+            LocalDate date,
+            int totalCount,
+            int completedCount,
+            int pendingCount,
+            int skippedCount,
+            int completionRate,
+            LocalDateTime plannedAt,
+            LocalDateTime lastRoutineModifiedAt,
+            LocalDateTime firstCompletedAt,
+            LocalDateTime lastCompletedAt,
+            List<RoutineTaskSummary> completedTasks,
+            List<RoutineTaskSummary> uncompletedTasks
+    ) {
+    }
+
+    public record RoutineTaskSummary(
+            String label,
+            LocalTime startTime,
+            LocalTime endTime,
+            String taskContent,
+            RoutinePeriodStatus status,
+            LocalDateTime completedAt
+    ) {
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/dto/MentorRequest.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/dto/MentorRequest.java
@@ -1,0 +1,20 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.dto;
+
+import java.time.LocalDate;
+
+public class MentorRequest {
+
+    public record SaveMentorPlanRequest(
+            String content
+    ) {
+    }
+
+    public record SaveDailyReflectionRequest(
+            LocalDate reflectionDate,
+            String mood,
+            String good,
+            String regret,
+            String freeText
+    ) {
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/dto/MentorResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/dto/MentorResponse.java
@@ -1,0 +1,136 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.dto;
+
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.DailyMentorFeedback;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.DailyReflection;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.MentorFeedbackSendStatus;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.MentorPlan;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.MentorPlanType;
+import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriodStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+public class MentorResponse {
+
+    public record MentorPlanResponse(
+            Long id,
+            MentorPlanType type,
+            String content,
+            Boolean active
+    ) {
+        public static MentorPlanResponse from(MentorPlan mentorPlan) {
+            return new MentorPlanResponse(
+                    mentorPlan.getId(),
+                    mentorPlan.getType(),
+                    mentorPlan.getContent(),
+                    mentorPlan.getActive()
+            );
+        }
+    }
+
+    public record CurrentMentorPlansResponse(
+            MentorPlanResponse careerPlan,
+            MentorPlanResponse monthlyPlan,
+            MentorPlanResponse weeklyPlan
+    ) {
+    }
+
+    public record DailyReflectionResponse(
+            Long id,
+            LocalDate reflectionDate,
+            String mood,
+            String good,
+            String regret,
+            String freeText,
+            LocalDateTime writtenAt
+    ) {
+        public static DailyReflectionResponse from(DailyReflection dailyReflection) {
+            return new DailyReflectionResponse(
+                    dailyReflection.getId(),
+                    dailyReflection.getReflectionDate(),
+                    dailyReflection.getMood(),
+                    dailyReflection.getGood(),
+                    dailyReflection.getRegret(),
+                    dailyReflection.getFreeText(),
+                    dailyReflection.getWrittenAt()
+            );
+        }
+    }
+
+    public record DailyMentorFeedbackResponse(
+            Long id,
+            LocalDate feedbackDate,
+            String promptSnapshot,
+            String feedbackContent,
+            LocalDateTime generatedAt,
+            MentorFeedbackSendStatus sendStatus
+    ) {
+        public static DailyMentorFeedbackResponse from(DailyMentorFeedback dailyMentorFeedback) {
+            return new DailyMentorFeedbackResponse(
+                    dailyMentorFeedback.getId(),
+                    dailyMentorFeedback.getFeedbackDate(),
+                    dailyMentorFeedback.getPromptSnapshot(),
+                    dailyMentorFeedback.getFeedbackContent(),
+                    dailyMentorFeedback.getGeneratedAt(),
+                    dailyMentorFeedback.getSendStatus()
+            );
+        }
+    }
+
+    public record DailyRoutineSummaryResponse(
+            LocalDate date,
+            int totalCount,
+            int completedCount,
+            int pendingCount,
+            int skippedCount,
+            int completionRate,
+            LocalDateTime plannedAt,
+            LocalDateTime lastRoutineModifiedAt,
+            LocalDateTime firstCompletedAt,
+            LocalDateTime lastCompletedAt,
+            List<RoutineTaskSummaryResponse> completedTasks,
+            List<RoutineTaskSummaryResponse> uncompletedTasks
+    ) {
+        public static DailyRoutineSummaryResponse from(MentorDto.DailyRoutineSummary summary) {
+            return new DailyRoutineSummaryResponse(
+                    summary.date(),
+                    summary.totalCount(),
+                    summary.completedCount(),
+                    summary.pendingCount(),
+                    summary.skippedCount(),
+                    summary.completionRate(),
+                    summary.plannedAt(),
+                    summary.lastRoutineModifiedAt(),
+                    summary.firstCompletedAt(),
+                    summary.lastCompletedAt(),
+                    summary.completedTasks().stream()
+                            .map(RoutineTaskSummaryResponse::from)
+                            .toList(),
+                    summary.uncompletedTasks().stream()
+                            .map(RoutineTaskSummaryResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record RoutineTaskSummaryResponse(
+            String label,
+            LocalTime startTime,
+            LocalTime endTime,
+            String taskContent,
+            RoutinePeriodStatus status,
+            LocalDateTime completedAt
+    ) {
+        public static RoutineTaskSummaryResponse from(MentorDto.RoutineTaskSummary task) {
+            return new RoutineTaskSummaryResponse(
+                    task.label(),
+                    task.startTime(),
+                    task.endTime(),
+                    task.taskContent(),
+                    task.status(),
+                    task.completedAt()
+            );
+        }
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/entity/DailyMentorFeedback.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/entity/DailyMentorFeedback.java
@@ -1,0 +1,57 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.entity;
+
+import com.hhd1337.jatuli_quiz.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyMentorFeedback extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate feedbackDate;
+
+    @Lob
+    private String promptSnapshot;
+
+    @Lob
+    private String feedbackContent;
+
+    private LocalDateTime generatedAt;
+
+    @Enumerated(EnumType.STRING)
+    private MentorFeedbackSendStatus sendStatus;
+
+    public DailyMentorFeedback(
+            LocalDate feedbackDate,
+            String promptSnapshot,
+            String feedbackContent
+    ) {
+        this.feedbackDate = feedbackDate;
+        this.promptSnapshot = promptSnapshot;
+        this.feedbackContent = feedbackContent;
+        this.generatedAt = LocalDateTime.now();
+        this.sendStatus = MentorFeedbackSendStatus.NOT_SENT;
+    }
+
+    public void regenerate(String promptSnapshot, String feedbackContent) {
+        this.promptSnapshot = promptSnapshot;
+        this.feedbackContent = feedbackContent;
+        this.generatedAt = LocalDateTime.now();
+        this.sendStatus = MentorFeedbackSendStatus.NOT_SENT;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/entity/DailyReflection.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/entity/DailyReflection.java
@@ -1,0 +1,67 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.entity;
+
+import com.hhd1337.jatuli_quiz.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyReflection extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDate reflectionDate;
+
+    @Column(length = 500)
+    private String mood;
+
+    @Column(length = 1000)
+    private String good;
+
+    @Column(length = 1000)
+    private String regret;
+
+    @Column(length = 3000)
+    private String freeText;
+
+    private LocalDateTime writtenAt;
+
+    public DailyReflection(
+            LocalDate reflectionDate,
+            String mood,
+            String good,
+            String regret,
+            String freeText
+    ) {
+        this.reflectionDate = reflectionDate;
+        this.mood = mood;
+        this.good = good;
+        this.regret = regret;
+        this.freeText = freeText;
+        this.writtenAt = LocalDateTime.now();
+    }
+
+    public void update(
+            String mood,
+            String good,
+            String regret,
+            String freeText
+    ) {
+        this.mood = mood;
+        this.good = good;
+        this.regret = regret;
+        this.freeText = freeText;
+        this.writtenAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/entity/MentorFeedbackSendStatus.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/entity/MentorFeedbackSendStatus.java
@@ -1,0 +1,6 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.entity;
+
+public enum MentorFeedbackSendStatus {
+    NOT_SENT,
+    SENT_TO_KAKAO
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/entity/MentorPlan.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/entity/MentorPlan.java
@@ -1,0 +1,45 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.entity;
+
+import com.hhd1337.jatuli_quiz.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MentorPlan extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private MentorPlanType type;
+
+    @Column(length = 5000)
+    private String content;
+
+    private Boolean active;
+
+    public MentorPlan(MentorPlanType type, String content) {
+        this.type = type;
+        this.content = content;
+        this.active = true;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/entity/MentorPlanType.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/entity/MentorPlanType.java
@@ -1,0 +1,7 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.entity;
+
+public enum MentorPlanType {
+    CAREER,
+    MONTHLY,
+    WEEKLY
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/repository/DailyMentorFeedbackRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/repository/DailyMentorFeedbackRepository.java
@@ -1,0 +1,11 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.repository;
+
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.DailyMentorFeedback;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyMentorFeedbackRepository extends JpaRepository<DailyMentorFeedback, Long> {
+
+    Optional<DailyMentorFeedback> findByFeedbackDate(LocalDate feedbackDate);
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/repository/DailyReflectionRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/repository/DailyReflectionRepository.java
@@ -1,0 +1,11 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.repository;
+
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.DailyReflection;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyReflectionRepository extends JpaRepository<DailyReflection, Long> {
+
+    Optional<DailyReflection> findByReflectionDate(LocalDate reflectionDate);
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/repository/MentorPlanRepository.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/repository/MentorPlanRepository.java
@@ -1,0 +1,14 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.repository;
+
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.MentorPlan;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.MentorPlanType;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentorPlanRepository extends JpaRepository<MentorPlan, Long> {
+
+    Optional<MentorPlan> findByTypeAndActiveTrue(MentorPlanType type);
+
+    List<MentorPlan> findAllByActiveTrue();
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/DailyMentorFeedbackService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/DailyMentorFeedbackService.java
@@ -1,0 +1,93 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.service;
+
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorDto;
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorResponse;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.DailyMentorFeedback;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.DailyReflection;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.MentorPlan;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.MentorPlanType;
+import com.hhd1337.jatuli_quiz.domain.mentor.repository.DailyMentorFeedbackRepository;
+import com.hhd1337.jatuli_quiz.domain.mentor.repository.DailyReflectionRepository;
+import com.hhd1337.jatuli_quiz.domain.mentor.repository.MentorPlanRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DailyMentorFeedbackService {
+
+    private final MentorPlanRepository mentorPlanRepository;
+    private final DailyReflectionRepository dailyReflectionRepository;
+    private final DailyMentorFeedbackRepository dailyMentorFeedbackRepository;
+    private final RoutineSummaryService routineSummaryService;
+    private final MentorPromptBuilder mentorPromptBuilder;
+    private final MentorFeedbackGenerator mentorFeedbackGenerator;
+
+    @Transactional
+    public MentorResponse.DailyMentorFeedbackResponse generateDailyFeedback(LocalDate date) {
+        String careerPlanContent = getActivePlanContent(
+                MentorPlanType.CAREER,
+                "아직 등록된 취업 전반 계획이 없습니다."
+        );
+
+        String monthlyPlanContent = getActivePlanContent(
+                MentorPlanType.MONTHLY,
+                "아직 등록된 이번달 계획이 없습니다."
+        );
+
+        String weeklyPlanContent = getActivePlanContent(
+                MentorPlanType.WEEKLY,
+                "아직 등록된 이번주 계획이 없습니다."
+        );
+
+        MentorDto.DailyRoutineSummary dailyRoutineSummary =
+                routineSummaryService.getDailyRoutineSummary(date);
+
+        DailyReflection dailyReflection = dailyReflectionRepository.findByReflectionDate(date)
+                .orElseThrow(() -> new IllegalArgumentException("해당 날짜의 오늘 소감이 없습니다. date=" + date));
+
+        String promptSnapshot = mentorPromptBuilder.build(
+                careerPlanContent,
+                monthlyPlanContent,
+                weeklyPlanContent,
+                dailyRoutineSummary,
+                dailyReflection
+        );
+
+        String feedbackContent = mentorFeedbackGenerator.generate(promptSnapshot);
+
+        DailyMentorFeedback dailyMentorFeedback = dailyMentorFeedbackRepository
+                .findByFeedbackDate(date)
+                .map(existingFeedback -> {
+                    existingFeedback.regenerate(promptSnapshot, feedbackContent);
+                    return existingFeedback;
+                })
+                .orElseGet(() -> dailyMentorFeedbackRepository.save(
+                        new DailyMentorFeedback(
+                                date,
+                                promptSnapshot,
+                                feedbackContent
+                        )
+                ));
+
+        return MentorResponse.DailyMentorFeedbackResponse.from(dailyMentorFeedback);
+    }
+
+    public MentorResponse.DailyMentorFeedbackResponse getDailyFeedback(LocalDate date) {
+        DailyMentorFeedback dailyMentorFeedback = dailyMentorFeedbackRepository.findByFeedbackDate(date)
+                .orElseThrow(() -> new IllegalArgumentException("해당 날짜의 AI 멘토 피드백이 없습니다. date=" + date));
+
+        return MentorResponse.DailyMentorFeedbackResponse.from(dailyMentorFeedback);
+    }
+
+    private String getActivePlanContent(MentorPlanType type, String fallbackMessage) {
+        return mentorPlanRepository.findByTypeAndActiveTrue(type)
+                .map(MentorPlan::getContent)
+                .filter(StringUtils::hasText)
+                .orElse(fallbackMessage);
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/DailyReflectionService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/DailyReflectionService.java
@@ -1,0 +1,59 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.service;
+
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorRequest;
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorResponse;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.DailyReflection;
+import com.hhd1337.jatuli_quiz.domain.mentor.repository.DailyReflectionRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DailyReflectionService {
+
+    private static final ZoneId KOREA_ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    private final DailyReflectionRepository dailyReflectionRepository;
+
+    @Transactional
+    public MentorResponse.DailyReflectionResponse saveDailyReflection(
+            MentorRequest.SaveDailyReflectionRequest request
+    ) {
+        LocalDate reflectionDate = request.reflectionDate() != null
+                ? request.reflectionDate()
+                : LocalDate.now(KOREA_ZONE_ID);
+
+        DailyReflection dailyReflection = dailyReflectionRepository.findByReflectionDate(reflectionDate)
+                .map(existingReflection -> {
+                    existingReflection.update(
+                            request.mood(),
+                            request.good(),
+                            request.regret(),
+                            request.freeText()
+                    );
+                    return existingReflection;
+                })
+                .orElseGet(() -> dailyReflectionRepository.save(
+                        new DailyReflection(
+                                reflectionDate,
+                                request.mood(),
+                                request.good(),
+                                request.regret(),
+                                request.freeText()
+                        )
+                ));
+
+        return MentorResponse.DailyReflectionResponse.from(dailyReflection);
+    }
+
+    public MentorResponse.DailyReflectionResponse getDailyReflection(LocalDate date) {
+        DailyReflection dailyReflection = dailyReflectionRepository.findByReflectionDate(date)
+                .orElseThrow(() -> new IllegalArgumentException("해당 날짜의 오늘 소감이 없습니다. date=" + date));
+
+        return MentorResponse.DailyReflectionResponse.from(dailyReflection);
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/FakeMentorFeedbackGenerator.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/FakeMentorFeedbackGenerator.java
@@ -1,0 +1,29 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.service;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class FakeMentorFeedbackGenerator implements MentorFeedbackGenerator {
+
+    @Override
+    public String generate(String prompt) {
+        return """
+                [오늘의 AI 멘토 피드백]
+                
+                1. 오늘 잘한 점
+                - 오늘 루틴을 기록하고 회고까지 남긴 점이 좋습니다.
+                
+                2. 아쉬운 점
+                - 완료하지 못한 항목이 있다면 내일은 오전 시간대부터 우선순위를 좁혀야 합니다.
+                
+                3. 현실적인 쓴소리
+                - 계획은 적는 것보다 실행률로 증명됩니다. 내일은 적게 잡고 반드시 끝내세요.
+                
+                4. 내일의 핵심 지시
+                - 첫 번째 공부 구간 하나만큼은 무조건 완료 처리하세요.
+                
+                5. 한 줄 응원
+                - 오늘의 기록은 내일의 방향이 됩니다.
+                """;
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/FakeMentorFeedbackGenerator.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/FakeMentorFeedbackGenerator.java
@@ -1,8 +1,13 @@
 package com.hhd1337.jatuli_quiz.domain.mentor.service;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnProperty(
+        name = "mentor.feedback.provider",
+        havingValue = "fake"
+)
 public class FakeMentorFeedbackGenerator implements MentorFeedbackGenerator {
 
     @Override

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/MentorFeedbackGenerator.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/MentorFeedbackGenerator.java
@@ -1,0 +1,6 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.service;
+
+public interface MentorFeedbackGenerator {
+
+    String generate(String prompt);
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/MentorPlanService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/MentorPlanService.java
@@ -1,0 +1,58 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.service;
+
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorRequest;
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorResponse;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.MentorPlan;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.MentorPlanType;
+import com.hhd1337.jatuli_quiz.domain.mentor.repository.MentorPlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MentorPlanService {
+
+    private final MentorPlanRepository mentorPlanRepository;
+
+    @Transactional
+    public MentorResponse.MentorPlanResponse savePlan(
+            MentorPlanType type,
+            MentorRequest.SaveMentorPlanRequest request
+    ) {
+        MentorPlan mentorPlan = mentorPlanRepository.findByTypeAndActiveTrue(type)
+                .map(existingPlan -> {
+                    existingPlan.updateContent(request.content());
+                    return existingPlan;
+                })
+                .orElseGet(() -> mentorPlanRepository.save(
+                        new MentorPlan(type, request.content())
+                ));
+
+        return MentorResponse.MentorPlanResponse.from(mentorPlan);
+    }
+
+    public MentorResponse.CurrentMentorPlansResponse getCurrentPlans() {
+        MentorResponse.MentorPlanResponse careerPlan = mentorPlanRepository
+                .findByTypeAndActiveTrue(MentorPlanType.CAREER)
+                .map(MentorResponse.MentorPlanResponse::from)
+                .orElse(null);
+
+        MentorResponse.MentorPlanResponse monthlyPlan = mentorPlanRepository
+                .findByTypeAndActiveTrue(MentorPlanType.MONTHLY)
+                .map(MentorResponse.MentorPlanResponse::from)
+                .orElse(null);
+
+        MentorResponse.MentorPlanResponse weeklyPlan = mentorPlanRepository
+                .findByTypeAndActiveTrue(MentorPlanType.WEEKLY)
+                .map(MentorResponse.MentorPlanResponse::from)
+                .orElse(null);
+
+        return new MentorResponse.CurrentMentorPlansResponse(
+                careerPlan,
+                monthlyPlan,
+                weeklyPlan
+        );
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/MentorPromptBuilder.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/MentorPromptBuilder.java
@@ -1,0 +1,126 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.service;
+
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorDto;
+import com.hhd1337.jatuli_quiz.domain.mentor.entity.DailyReflection;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MentorPromptBuilder {
+
+    public String build(
+            String careerPlanContent,
+            String monthlyPlanContent,
+            String weeklyPlanContent,
+            MentorDto.DailyRoutineSummary routineSummary,
+            DailyReflection reflection
+    ) {
+        return """
+                너는 사용자의 1대1 취업 준비 AI 멘토다.
+                사용자는 백엔드 신입 개발자 취업을 준비하고 있다.
+                
+                피드백은 다음 형식을 반드시 지켜라.
+                
+                [오늘의 AI 멘토 피드백]
+                
+                1. 오늘 잘한 점
+                - ...
+                
+                2. 아쉬운 점
+                - ...
+                
+                3. 현실적인 쓴소리
+                - ...
+                
+                4. 내일의 핵심 지시
+                - ...
+                
+                5. 한 줄 응원
+                - ...
+                
+                [취업 전반 계획]
+                %s
+                
+                [이번달 계획]
+                %s
+                
+                [이번주 계획]
+                %s
+                
+                [오늘 루틴 요약]
+                날짜: %s
+                전체 구간 수: %d
+                완료 구간 수: %d
+                대기 구간 수: %d
+                건너뜀 구간 수: %d
+                미완료 구간 수: %d
+                완료율: %d%%
+                계획 등록 시각: %s
+                마지막 수정 시각: %s
+                첫 완료 시각: %s
+                마지막 완료 시각: %s
+                
+                [완료한 일 목록]
+                %s
+                
+                [미완료한 일 목록]
+                %s
+                
+                [오늘 소감]
+                컨디션/감정: %s
+                잘한 점: %s
+                아쉬운 점: %s
+                자유 소감: %s
+                소감 작성 시각: %s
+                
+                주의:
+                - 사용자를 무작정 위로하지 마라.
+                - 잘한 점은 구체적으로 칭찬하라.
+                - 아쉬운 점은 실행 행동 기준으로 지적하라.
+                - 현실적인 쓴소리는 비난이 아니라 행동 교정 중심으로 작성하라.
+                - 내일 행동 지시는 1~3개로 제한하라.
+                - 매일 읽을 수 있도록 너무 길게 쓰지 마라.
+                """.formatted(
+                careerPlanContent,
+                monthlyPlanContent,
+                weeklyPlanContent,
+                routineSummary.date(),
+                routineSummary.totalCount(),
+                routineSummary.completedCount(),
+                routineSummary.pendingCount(),
+                routineSummary.skippedCount(),
+                routineSummary.pendingCount() + routineSummary.skippedCount(),
+                routineSummary.completionRate(),
+                routineSummary.plannedAt(),
+                routineSummary.lastRoutineModifiedAt(),
+                routineSummary.firstCompletedAt(),
+                routineSummary.lastCompletedAt(),
+                formatTasks(routineSummary.completedTasks()),
+                formatTasks(routineSummary.uncompletedTasks()),
+                reflection.getMood(),
+                reflection.getGood(),
+                reflection.getRegret(),
+                reflection.getFreeText(),
+                reflection.getWrittenAt()
+        );
+    }
+
+    private String formatTasks(java.util.List<MentorDto.RoutineTaskSummary> tasks) {
+        if (tasks == null || tasks.isEmpty()) {
+            return "- 없음";
+        }
+
+        return tasks.stream()
+                .map(task -> "- [%s ~ %s] %s: %s 상태=%s 완료시각=%s".formatted(
+                        task.startTime(),
+                        task.endTime(),
+                        task.label(),
+                        task.taskContent(),
+                        task.status(),
+                        task.completedAt()
+                ))
+                .toList()
+                .stream()
+                .reduce((a, b) -> a + "\n" + b)
+                .orElse("- 없음");
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/MentorPromptBuilder.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/MentorPromptBuilder.java
@@ -2,6 +2,8 @@ package com.hhd1337.jatuli_quiz.domain.mentor.service;
 
 import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorDto;
 import com.hhd1337.jatuli_quiz.domain.mentor.entity.DailyReflection;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,28 +16,121 @@ public class MentorPromptBuilder {
             MentorDto.DailyRoutineSummary routineSummary,
             DailyReflection reflection
     ) {
+        int totalCount = safeInt(routineSummary.totalCount());
+        int completedCount = safeInt(routineSummary.completedCount());
+        int pendingCount = safeInt(routineSummary.pendingCount());
+        int skippedCount = safeInt(routineSummary.skippedCount());
+        int uncompletedCount = pendingCount + skippedCount;
+        int completionRate = safeInt(routineSummary.completionRate());
+
+        String completedTasksText = formatTasks(routineSummary.completedTasks());
+        String uncompletedTasksText = formatTasks(routineSummary.uncompletedTasks());
+
         return """
-                너는 사용자의 1대1 취업 준비 AI 멘토다.
-                사용자는 백엔드 신입 개발자 취업을 준비하고 있다.
+                당신은 30년 경력의 유능한 백엔드 신입 개발자 취업 준비 멘토입니다.
+                의뢰인은 2027년 상반기 백엔드 신입 개발자 취업을 목표로 준비하고 있습니다.
+                사용자는 Java/Spring/MySQL 기반 백엔드 신입 개발자를 지망하며, 취업 준비 기간은 2026년 6월부터 2027년 2월까지 약 9개월입니다.
                 
-                피드백은 다음 형식을 반드시 지켜라.
+                당신의 역할은 오늘 하루를 냉정하게 채점하여 사용자에게 오늘 하루가 어땠는지 정확히 알리는 것과 더불어,
+                사용자가 9개월 동안 나태해지지 않고, 지치지 않고, 무너지더라도 다시 복구하면서, 백엔드 신입 취업이라는 장기 목표에 계속 가까워지도록 돕는 것입니다.
                 
-                [오늘의 AI 멘토 피드백]
+                사용자의 성향과 약점은 다음과 같습니다.
                 
-                1. 오늘 잘한 점
-                - ...
+                [사용자 성향 및 멘탈 패턴]
+                - 사용자는 기본적으로 현실적인 쓴소리를 듣고싶고, 논리적인 피드백을 선호한다.
+                - 사용자는 취업 실패에 대한 불안감이 매우 큰 편이다. 취업에 대한 압박이 깊기 때문에 불안이 엔진이 아니라 브레이크가 되는 순간이 많다.
+                - 사용자의 불안은 이런 식으로도 흘러간다. 취업 실패하면 큰일난다 → 시작이 무겁다 → 회피한다 → 회피한 나를 보고 더 불안해진다
+                - 사용자는 루틴이 한 번 깨지면 자책이 커지고, 그 때문에 복구력이 약해지는 패턴이 종종 있다.
+                - 사용자는 즉각적인 보상에 약하다. 쇼츠, 웹툰, 게임, 음식, 수면 같은 빠른 보상으로 회피하기 쉽다.
+                - 사용자는 작은 실패를 "오늘 행동의 실패"가 아니라 "나는 안 되는 사람"이라는 자기불신으로 해석하기 쉽다.
+                - 사용자는 자기불신이 강해서 작은 실패를 크게 해석한다. 내가 또 이러네, 나는 왜 이렇게 못하지, 내가 취업할 수 있을까 쪽으로 쉽게 빠진다.
+                - 사용자는 성취감이 보이면 강하게 몰입하지만, 성취감이 안 보이면 지속력이 떨어지곤 한다.
+                - 사용자는 간절할 때, 성취해본 경험이 많다. 가령 대학교공부에 뒤쳐지다 정신을 차리자, 간절하게 공부하여 F과목 13개를 재수강하고, 과탑을 3번이나 했다.
+                - 사용자는 취업이 간절하지만, 그 간절함을 즉각적인 보상 때문에 종종 잊어버린다.
                 
-                2. 아쉬운 점
-                - ...
+                따라서 당신은 사용자가 오늘 어떤 상태였는지 정확히 판정하고, 전체 취업준비 흐름에서 어떤 의미가 있는지 설명하고,
+                내일 다시 움직일 수 있도록 소감에 대해 피드백해야 한다. 또한 가장 중요한 것은 취업이 간절함을 계속 상기시켜야 한다.
                 
-                3. 현실적인 쓴소리
-                - ...
+                [소감 작성 해석]
                 
-                4. 내일의 핵심 지시
-                - ...
+                소감을 작성한 경우:
+                - 소감을 자세히 보고, 위 "사용자 성향 및 멘탈 패턴"에 맞게 좋은말이나 혹은 쓴소리를 반드시 강하게 해줄 것.
                 
-                5. 한 줄 응원
-                - ...
+                소감이 부실하거나 없는 경우:
+                - 하루를 닫는 루틴이 약해졌다고 지적하라.
+                - 내일은 소감 3줄이라도 반드시 작성하라고 지시하라.
+                
+                [표현 톤]
+                
+                - 아쉬운 점을 말할 때는, 대기업에 취업가능한지, 취업준비생 상위 1프로에 들어갈 노력과 공부내용을 했는지, 냉정하고 현실적으로 지적해야 한다.
+                - 핵심은 "너는 할 수 있다. 너는 될 사람이다. 너는 2027년 3월에 빅테크에 당당히 합격할 것이다." 이다.
+                - 재수, 삼수, 쇼핑몰, 대학교 F 13개 복구 및 과탑 3회 등을 거쳐왔다. 이제 2027년 3월에 취업이 이 일련의 과정의 마지막 관문이다. 라는 것을 상기시켜라.
+                - 사용자가 다시 책상에 앉고 싶어지게, 간절히 취업을 하고싶게 만들어라.
+                
+                [출력 형식]
+                
+                출력은 마크다운 문법으로 작성하라.
+                단, 과하게 꾸미지 말고 담백한 회고 문서처럼 작성하라.
+                
+                반드시 아래 규칙을 지켜라.
+                - 주요 섹션 제목은 `## 숫자. 제목` 형식을 사용한다.
+                - 각 주요 섹션 사이에는 빈 줄을 한 줄 이상 둔다.
+                - `## 1. 오늘 평가` 섹션 안에는 반드시 아래 세 개의 굵은 소제목을 모두 포함한다.
+                  - `**취업준비 흐름 기준**`
+                  - `**오늘 소감에 대한 피드백**`
+                  - `**오늘 간절했는가**`
+                - 위 세 개의 소제목은 `##` 제목 문법을 쓰지 말고, 반드시 `**굵은 글씨**`로만 표시한다.
+                - 각 소제목 아래에는 `-` 목록으로 1~2개의 피드백을 작성한다.
+                - 항목은 `-` 목록으로 작성한다.
+                - 표는 사용하지 않는다.
+                - 코드블록은 사용하지 않는다.
+                - 입력 데이터 제목인 [취업 전반 계획], [이번달 계획], [이번주 계획], [오늘 루틴 요약], [완료한 일 목록], [미완료한 일 목록], [오늘 소감]을 출력에 다시 쓰지 마라.
+                - 전체 피드백은 2000자 이내로 작성한다.
+                - 마지막 섹션까지 작성한 뒤 즉시 출력을 종료한다.
+                
+                반드시 아래 마크다운 형식을 지켜라.
+                
+                ## 1. 오늘 평가
+                
+                **취업준비 흐름 기준**
+                - 준비기간 전체, 이번달 계획, 이번주 계획과 비교해 오늘 하루가 어떤 의미였는지 평가한다.
+                - 오늘의 실행이 백엔드 신입 취업이라는 장기 목표에 가까워졌는지 냉정하게 판단한다.
+                
+                **오늘 소감에 대한 피드백**
+                - 사용자가 적은 컨디션, 잘한 점, 아쉬운 점, 자유 소감을 근거로 피드백한다.
+                - 소감이 부실하면 하루를 닫는 루틴이 약하다고 지적한다.
+                
+                **오늘 간절했는가**
+                - 오늘의 행동이 정말 취업을 간절히 원하는 사람의 행동이었는지 판단한다.
+                - 부족했다면 변명 없이 지적하고, 내일 어떤 기준으로 바꿔야 하는지 말한다.
+                
+                ---
+                
+                ## 2. 오늘 잘한 점
+                
+                -\s
+                -\s
+                
+                ---
+                
+                ## 3. 오늘 아쉬운 점
+                
+                -\s
+                -\s
+                
+                ---
+                
+                ## 4. 현실적인 쓴소리
+                
+                -\s
+                
+                ---
+                
+                ## 5. 응원 및 간절함 상기
+                
+                -\s
+                
+                -----------------------------------
                 
                 [취업 전반 계획]
                 %s
@@ -72,55 +167,74 @@ public class MentorPromptBuilder {
                 자유 소감: %s
                 소감 작성 시각: %s
                 
-                주의:
+                [최종 주의사항]
                 - 사용자를 무작정 위로하지 마라.
-                - 잘한 점은 구체적으로 칭찬하라.
-                - 아쉬운 점은 실행 행동 기준으로 지적하라.
-                - 현실적인 쓴소리는 비난이 아니라 행동 교정 중심으로 작성하라.
-                - 내일 행동 지시는 1~3개로 제한하라.
-                - 매일 읽을 수 있도록 너무 길게 쓰지 마라.
+                - 전체 계획, 이번달 계획, 이번주 계획과 연결해서 평가하라.
+                - 오늘 루틴 요약, 완료한 일 목록, 미완료한 일 목록, 오늘소감을 반드시 분석하여 모든 답변에 그것들을 근거로 답하라.
+                - `## 1. 오늘 평가` 아래에는 반드시 `**취업준비 흐름 기준**`, `**오늘 소감에 대한 피드백**`, `**오늘 간절했는가**` 세 소제목을 모두 출력하라.
+                - `## 1. 오늘 평가`, `## 2. 오늘 잘한 점`, `## 3. 오늘 아쉬운 점`, `## 4. 현실적인 쓴소리` 섹션 뒤에는 반드시 `---` 구분선을 출력하라.
+                - `---` 구분선 앞뒤에는 빈 줄을 한 줄씩 둬라.
+                - `## 5. 응원 및 간절함 상기` 뒤에는 `---`를 출력하지 마라.
+                - 출력에는 입력 데이터 원문을 다시 복붙하지 마라.
+                - `## 5. 응원 및 간절함 상기` 섹션까지 작성한 뒤 즉시 종료하라.
+                - 전체 피드백은 2000자 이내로 작성하라.
                 """.formatted(
-                careerPlanContent,
-                monthlyPlanContent,
-                weeklyPlanContent,
-                routineSummary.date(),
-                routineSummary.totalCount(),
-                routineSummary.completedCount(),
-                routineSummary.pendingCount(),
-                routineSummary.skippedCount(),
-                routineSummary.pendingCount() + routineSummary.skippedCount(),
-                routineSummary.completionRate(),
-                routineSummary.plannedAt(),
-                routineSummary.lastRoutineModifiedAt(),
-                routineSummary.firstCompletedAt(),
-                routineSummary.lastCompletedAt(),
-                formatTasks(routineSummary.completedTasks()),
-                formatTasks(routineSummary.uncompletedTasks()),
-                reflection.getMood(),
-                reflection.getGood(),
-                reflection.getRegret(),
-                reflection.getFreeText(),
-                reflection.getWrittenAt()
+                safeText(careerPlanContent),
+                safeText(monthlyPlanContent),
+                safeText(weeklyPlanContent),
+                safeText(routineSummary.date()),
+                totalCount,
+                completedCount,
+                pendingCount,
+                skippedCount,
+                uncompletedCount,
+                completionRate,
+                safeText(routineSummary.plannedAt()),
+                safeText(routineSummary.lastRoutineModifiedAt()),
+                safeText(routineSummary.firstCompletedAt()),
+                safeText(routineSummary.lastCompletedAt()),
+                completedTasksText,
+                uncompletedTasksText,
+                safeText(reflection.getMood()),
+                safeText(reflection.getGood()),
+                safeText(reflection.getRegret()),
+                safeText(reflection.getFreeText()),
+                safeText(reflection.getWrittenAt())
         );
     }
 
-    private String formatTasks(java.util.List<MentorDto.RoutineTaskSummary> tasks) {
+    private String formatTasks(List<MentorDto.RoutineTaskSummary> tasks) {
         if (tasks == null || tasks.isEmpty()) {
             return "- 없음";
         }
 
         return tasks.stream()
                 .map(task -> "- [%s ~ %s] %s: %s 상태=%s 완료시각=%s".formatted(
-                        task.startTime(),
-                        task.endTime(),
-                        task.label(),
-                        task.taskContent(),
-                        task.status(),
-                        task.completedAt()
+                        safeText(task.startTime()),
+                        safeText(task.endTime()),
+                        safeText(task.label()),
+                        safeText(task.taskContent()),
+                        safeText(task.status()),
+                        safeText(task.completedAt())
                 ))
-                .toList()
-                .stream()
-                .reduce((a, b) -> a + "\n" + b)
-                .orElse("- 없음");
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String safeText(Object value) {
+        if (value == null) {
+            return "없음";
+        }
+
+        String text = String.valueOf(value).trim();
+
+        if (text.isBlank()) {
+            return "없음";
+        }
+
+        return text;
+    }
+
+    private int safeInt(Integer value) {
+        return value == null ? 0 : value;
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/OpenAiMentorFeedbackGenerator.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/OpenAiMentorFeedbackGenerator.java
@@ -1,0 +1,202 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.service;
+
+import com.hhd1337.jatuli_quiz.domain.mentor.config.OpenAiProperties;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import tools.jackson.databind.JsonNode;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(
+        name = "mentor.feedback.provider",
+        havingValue = "openai",
+        matchIfMissing = true
+)
+public class OpenAiMentorFeedbackGenerator implements MentorFeedbackGenerator {
+
+    private static final String SYSTEM_INSTRUCTION = """
+            너는 사용자의 1대1 취업 준비 AI 멘토다.
+            사용자의 루틴 수행 결과, 장기 계획, 월간 계획, 주간 계획, 오늘 소감을 바탕으로 하루 피드백을 작성한다.
+            
+            반드시 다음 원칙을 지켜라.
+            - 한국어로 작성한다.
+            - 사용자를 무작정 위로하지 않는다.
+            - 잘한 점은 구체적으로 칭찬한다.
+            - 아쉬운 점은 실행 행동 기준으로 지적한다.
+            - 현실적인 쓴소리는 비난이 아니라 행동 교정 중심으로 작성한다.
+            - 내일 행동 지시는 1~3개로 제한한다.
+            - 매일 읽을 수 있도록 너무 길게 쓰지 않는다.
+            - 출력 형식은 사용자가 제공한 프롬프트의 형식을 따른다.
+            """;
+
+    private final OpenAiProperties openAiProperties;
+    private final RestClient restClient;
+
+    public OpenAiMentorFeedbackGenerator(OpenAiProperties openAiProperties) {
+        this.openAiProperties = openAiProperties;
+        this.restClient = createRestClient(openAiProperties);
+    }
+
+    @Override
+    public String generate(String prompt) {
+        validateRequiredProperties();
+
+        if (!StringUtils.hasText(prompt)) {
+            throw new IllegalArgumentException("AI 멘토 피드백 생성을 위한 프롬프트가 비어 있습니다.");
+        }
+
+        Map<String, Object> requestBody = buildRequestBody(prompt);
+
+        try {
+            JsonNode responseBody = restClient.post()
+                    .uri("/responses")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(requestBody)
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            return extractFeedbackContent(responseBody);
+        } catch (RestClientResponseException exception) {
+            log.error(
+                    "OpenAI API 응답 오류. status={}, body={}",
+                    exception.getStatusCode(),
+                    exception.getResponseBodyAsString(),
+                    exception
+            );
+
+            throw new IllegalStateException("AI 멘토 피드백 생성 중 OpenAI API 응답 오류가 발생했습니다.");
+        } catch (RestClientException exception) {
+            log.error("OpenAI API 호출 실패", exception);
+
+            throw new IllegalStateException("AI 멘토 피드백 생성 중 OpenAI API 호출에 실패했습니다.");
+        }
+    }
+
+    private RestClient createRestClient(OpenAiProperties properties) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        Duration timeout = Duration.ofSeconds(Math.max(1, properties.getTimeoutSeconds()));
+
+        requestFactory.setConnectTimeout(timeout);
+        requestFactory.setReadTimeout(timeout);
+
+        return RestClient.builder()
+                .baseUrl(properties.getNormalizedBaseUrl())
+                .requestFactory(requestFactory)
+                .defaultHeader("Authorization", "Bearer " + properties.getApiKey())
+                .defaultHeader("Accept", MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    private Map<String, Object> buildRequestBody(String prompt) {
+        Map<String, Object> requestBody = new LinkedHashMap<>();
+
+        requestBody.put("model", openAiProperties.getModel());
+
+        List<Map<String, Object>> input = new ArrayList<>();
+
+        input.add(Map.of(
+                "role", "developer",
+                "content", SYSTEM_INSTRUCTION
+        ));
+
+        input.add(Map.of(
+                "role", "user",
+                "content", prompt
+        ));
+
+        requestBody.put("input", input);
+
+        if (openAiProperties.getMaxOutputTokens() > 0) {
+            requestBody.put("max_output_tokens", openAiProperties.getMaxOutputTokens());
+        }
+
+        return requestBody;
+    }
+
+    private String extractFeedbackContent(JsonNode responseBody) {
+        if (responseBody == null || responseBody.isNull()) {
+            throw new IllegalStateException("OpenAI API 응답이 비어 있습니다.");
+        }
+
+        JsonNode errorNode = responseBody.path("error");
+
+        if (!errorNode.isMissingNode() && !errorNode.isNull()) {
+            String errorMessage = errorNode.path("message").asText("알 수 없는 OpenAI API 오류");
+            throw new IllegalStateException("OpenAI API 오류: " + errorMessage);
+        }
+
+        String status = responseBody.path("status").asText("");
+
+        if ("incomplete".equals(status)) {
+            String reason = responseBody.path("incomplete_details").path("reason").asText("unknown");
+            throw new IllegalStateException("OpenAI API 응답이 완성되지 않았습니다. reason=" + reason);
+        }
+
+        String outputText = extractOutputText(responseBody);
+
+        if (!StringUtils.hasText(outputText)) {
+            log.error("OpenAI API 응답에서 피드백 텍스트를 추출하지 못했습니다. response={}", responseBody);
+            throw new IllegalStateException("OpenAI API 응답에서 피드백 내용을 찾지 못했습니다.");
+        }
+
+        return outputText.trim();
+    }
+
+    private String extractOutputText(JsonNode responseBody) {
+        JsonNode outputTextNode = responseBody.path("output_text");
+
+        if (outputTextNode.isTextual() && StringUtils.hasText(outputTextNode.asText())) {
+            return outputTextNode.asText();
+        }
+
+        StringBuilder builder = new StringBuilder();
+
+        JsonNode outputNode = responseBody.path("output");
+
+        if (outputNode.isArray()) {
+            for (JsonNode outputItem : outputNode) {
+                JsonNode contentNode = outputItem.path("content");
+
+                if (!contentNode.isArray()) {
+                    continue;
+                }
+
+                for (JsonNode contentItem : contentNode) {
+                    JsonNode textNode = contentItem.path("text");
+
+                    if (textNode.isTextual() && StringUtils.hasText(textNode.asText())) {
+                        if (!builder.isEmpty()) {
+                            builder.append("\n");
+                        }
+
+                        builder.append(textNode.asText());
+                    }
+                }
+            }
+        }
+
+        return builder.toString();
+    }
+
+    private void validateRequiredProperties() {
+        if (!StringUtils.hasText(openAiProperties.getApiKey())) {
+            throw new IllegalStateException("OPENAI_API_KEY가 설정되어 있지 않습니다.");
+        }
+
+        if (!StringUtils.hasText(openAiProperties.getModel())) {
+            throw new IllegalStateException("OPENAI_MODEL이 설정되어 있지 않습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/RoutineSummaryService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/RoutineSummaryService.java
@@ -4,6 +4,7 @@ import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorDto;
 import com.hhd1337.jatuli_quiz.domain.routine.entity.DailyRoutine;
 import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriod;
 import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriodStatus;
+import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriodType;
 import com.hhd1337.jatuli_quiz.domain.routine.repository.DailyRoutineRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -24,19 +25,22 @@ public class RoutineSummaryService {
         DailyRoutine dailyRoutine = dailyRoutineRepository.findByRoutineDate(date)
                 .orElseThrow(() -> new IllegalArgumentException("해당 날짜의 루틴이 없습니다. date=" + date));
 
-        List<RoutinePeriod> periods = dailyRoutine.getPeriods();
+        List<RoutinePeriod> taskPeriods = dailyRoutine.getPeriods()
+                .stream()
+                .filter(this::isTaskTargetPeriod)
+                .toList();
 
-        int totalCount = periods.size();
+        int totalCount = taskPeriods.size();
 
-        int completedCount = (int) periods.stream()
+        int completedCount = (int) taskPeriods.stream()
                 .filter(period -> period.getStatus() == RoutinePeriodStatus.COMPLETED)
                 .count();
 
-        int pendingCount = (int) periods.stream()
+        int pendingCount = (int) taskPeriods.stream()
                 .filter(period -> period.getStatus() == RoutinePeriodStatus.PENDING)
                 .count();
 
-        int skippedCount = (int) periods.stream()
+        int skippedCount = (int) taskPeriods.stream()
                 .filter(period -> period.getStatus() == RoutinePeriodStatus.SKIPPED)
                 .count();
 
@@ -44,26 +48,26 @@ public class RoutineSummaryService {
                 ? 0
                 : (int) Math.round((completedCount * 100.0) / totalCount);
 
-        LocalDateTime firstCompletedAt = periods.stream()
+        LocalDateTime firstCompletedAt = taskPeriods.stream()
                 .filter(period -> period.getStatus() == RoutinePeriodStatus.COMPLETED)
                 .map(RoutinePeriod::getCompletedAt)
                 .filter(completedAt -> completedAt != null)
                 .min(Comparator.naturalOrder())
                 .orElse(null);
 
-        LocalDateTime lastCompletedAt = periods.stream()
+        LocalDateTime lastCompletedAt = taskPeriods.stream()
                 .filter(period -> period.getStatus() == RoutinePeriodStatus.COMPLETED)
                 .map(RoutinePeriod::getCompletedAt)
                 .filter(completedAt -> completedAt != null)
                 .max(Comparator.naturalOrder())
                 .orElse(null);
 
-        List<MentorDto.RoutineTaskSummary> completedTasks = periods.stream()
+        List<MentorDto.RoutineTaskSummary> completedTasks = taskPeriods.stream()
                 .filter(period -> period.getStatus() == RoutinePeriodStatus.COMPLETED)
                 .map(this::toRoutineTaskSummary)
                 .toList();
 
-        List<MentorDto.RoutineTaskSummary> uncompletedTasks = periods.stream()
+        List<MentorDto.RoutineTaskSummary> uncompletedTasks = taskPeriods.stream()
                 .filter(period -> period.getStatus() != RoutinePeriodStatus.COMPLETED)
                 .map(this::toRoutineTaskSummary)
                 .toList();
@@ -82,6 +86,10 @@ public class RoutineSummaryService {
                 completedTasks,
                 uncompletedTasks
         );
+    }
+
+    private boolean isTaskTargetPeriod(RoutinePeriod period) {
+        return period.getType() != RoutinePeriodType.BREAK;
     }
 
     private MentorDto.RoutineTaskSummary toRoutineTaskSummary(RoutinePeriod period) {

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/RoutineSummaryService.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/mentor/service/RoutineSummaryService.java
@@ -1,0 +1,97 @@
+package com.hhd1337.jatuli_quiz.domain.mentor.service;
+
+import com.hhd1337.jatuli_quiz.domain.mentor.dto.MentorDto;
+import com.hhd1337.jatuli_quiz.domain.routine.entity.DailyRoutine;
+import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriod;
+import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriodStatus;
+import com.hhd1337.jatuli_quiz.domain.routine.repository.DailyRoutineRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoutineSummaryService {
+
+    private final DailyRoutineRepository dailyRoutineRepository;
+
+    public MentorDto.DailyRoutineSummary getDailyRoutineSummary(LocalDate date) {
+        DailyRoutine dailyRoutine = dailyRoutineRepository.findByRoutineDate(date)
+                .orElseThrow(() -> new IllegalArgumentException("해당 날짜의 루틴이 없습니다. date=" + date));
+
+        List<RoutinePeriod> periods = dailyRoutine.getPeriods();
+
+        int totalCount = periods.size();
+
+        int completedCount = (int) periods.stream()
+                .filter(period -> period.getStatus() == RoutinePeriodStatus.COMPLETED)
+                .count();
+
+        int pendingCount = (int) periods.stream()
+                .filter(period -> period.getStatus() == RoutinePeriodStatus.PENDING)
+                .count();
+
+        int skippedCount = (int) periods.stream()
+                .filter(period -> period.getStatus() == RoutinePeriodStatus.SKIPPED)
+                .count();
+
+        int completionRate = totalCount == 0
+                ? 0
+                : (int) Math.round((completedCount * 100.0) / totalCount);
+
+        LocalDateTime firstCompletedAt = periods.stream()
+                .filter(period -> period.getStatus() == RoutinePeriodStatus.COMPLETED)
+                .map(RoutinePeriod::getCompletedAt)
+                .filter(completedAt -> completedAt != null)
+                .min(Comparator.naturalOrder())
+                .orElse(null);
+
+        LocalDateTime lastCompletedAt = periods.stream()
+                .filter(period -> period.getStatus() == RoutinePeriodStatus.COMPLETED)
+                .map(RoutinePeriod::getCompletedAt)
+                .filter(completedAt -> completedAt != null)
+                .max(Comparator.naturalOrder())
+                .orElse(null);
+
+        List<MentorDto.RoutineTaskSummary> completedTasks = periods.stream()
+                .filter(period -> period.getStatus() == RoutinePeriodStatus.COMPLETED)
+                .map(this::toRoutineTaskSummary)
+                .toList();
+
+        List<MentorDto.RoutineTaskSummary> uncompletedTasks = periods.stream()
+                .filter(period -> period.getStatus() != RoutinePeriodStatus.COMPLETED)
+                .map(this::toRoutineTaskSummary)
+                .toList();
+
+        return new MentorDto.DailyRoutineSummary(
+                dailyRoutine.getRoutineDate(),
+                totalCount,
+                completedCount,
+                pendingCount,
+                skippedCount,
+                completionRate,
+                dailyRoutine.getPlannedAt(),
+                dailyRoutine.getLastModifiedAt(),
+                firstCompletedAt,
+                lastCompletedAt,
+                completedTasks,
+                uncompletedTasks
+        );
+    }
+
+    private MentorDto.RoutineTaskSummary toRoutineTaskSummary(RoutinePeriod period) {
+        return new MentorDto.RoutineTaskSummary(
+                period.getLabel(),
+                period.getStartTime(),
+                period.getEndTime(),
+                period.getTaskContent(),
+                period.getStatus(),
+                period.getCompletedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/converter/RoutineConverter.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/converter/RoutineConverter.java
@@ -31,6 +31,8 @@ public class RoutineConverter {
         return new RoutineResponse.DailyRoutineResponse(
                 routine.getId(),
                 routine.getRoutineDate(),
+                routine.getPlannedAt(),
+                routine.getLastModifiedAt(),
                 periods
         );
     }
@@ -44,7 +46,8 @@ public class RoutineConverter {
                 period.getTaskContent(),
                 period.getSortOrder(),
                 period.getType(),
-                period.getStatus()
+                period.getStatus(),
+                period.getCompletedAt()
         );
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/dto/RoutineResponse.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/dto/RoutineResponse.java
@@ -3,6 +3,7 @@ package com.hhd1337.jatuli_quiz.domain.routine.dto;
 import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriodStatus;
 import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriodType;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -11,6 +12,8 @@ public class RoutineResponse {
     public record DailyRoutineResponse(
             Long routineId,
             LocalDate routineDate,
+            LocalDateTime plannedAt,
+            LocalDateTime lastModifiedAt,
             List<RoutinePeriodResponse> periods
     ) {
     }
@@ -23,7 +26,8 @@ public class RoutineResponse {
             String taskContent,
             Integer sortOrder,
             RoutinePeriodType type,
-            RoutinePeriodStatus status
+            RoutinePeriodStatus status,
+            LocalDateTime completedAt
     ) {
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/DailyRoutine.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/DailyRoutine.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -26,12 +27,20 @@ public class DailyRoutine extends BaseEntity {
 
     private LocalDate routineDate;
 
+    private LocalDateTime plannedAt;
+
+    private LocalDateTime lastModifiedAt;
+
     @OneToMany(mappedBy = "dailyRoutine", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("sortOrder asc")
     private List<RoutinePeriod> periods = new ArrayList<>();
 
     public DailyRoutine(LocalDate routineDate) {
+        LocalDateTime now = LocalDateTime.now();
+
         this.routineDate = routineDate;
+        this.plannedAt = now;
+        this.lastModifiedAt = now;
     }
 
     public void replacePeriods(List<RoutinePeriod> newPeriods) {
@@ -41,5 +50,7 @@ public class DailyRoutine extends BaseEntity {
             period.setDailyRoutine(this);
             this.periods.add(period);
         }
+
+        this.lastModifiedAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/RoutinePeriod.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/entity/RoutinePeriod.java
@@ -70,13 +70,17 @@ public class RoutinePeriod extends BaseEntity {
         this.dailyRoutine = dailyRoutine;
     }
 
-    public void complete() {
+    public void complete(LocalDateTime completedAt) {
+        if (this.status != RoutinePeriodStatus.COMPLETED) {
+            this.completedAt = completedAt;
+        }
+
         this.status = RoutinePeriodStatus.COMPLETED;
-        this.completedAt = LocalDateTime.now();
     }
 
     public void skip() {
         this.status = RoutinePeriodStatus.SKIPPED;
+        this.completedAt = null;
     }
 
     public void resetToPending() {

--- a/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/service/RoutineServiceImpl.java
+++ b/backend/src/main/java/com/hhd1337/jatuli_quiz/domain/routine/service/RoutineServiceImpl.java
@@ -9,6 +9,7 @@ import com.hhd1337.jatuli_quiz.domain.routine.entity.RoutinePeriod;
 import com.hhd1337.jatuli_quiz.domain.routine.repository.DailyRoutineRepository;
 import com.hhd1337.jatuli_quiz.domain.routine.repository.RoutinePeriodRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -84,7 +85,7 @@ public class RoutineServiceImpl implements RoutineService {
         RoutinePeriod period = routinePeriodRepository.findById(periodId)
                 .orElseThrow(() -> new IllegalArgumentException("루틴 구간을 찾을 수 없습니다."));
 
-        period.complete();
+        period.complete(LocalDateTime.now());
 
         return routineConverter.toDailyRoutineResponse(period.getDailyRoutine());
     }

--- a/frontend/src/app/router.jsx
+++ b/frontend/src/app/router.jsx
@@ -8,6 +8,8 @@ import QuizEditPage from "../pages/quiz/QuizEditPage";
 import RoutinePage from "../pages/routine/RoutinePage";
 import NotFoundPage from "../pages/error/NotFoundPage";
 import HealthCheckPage from "../pages/test/HealthCheckPage";
+import MentorPlanPage from "../pages/mentor/MentorPlanPage";
+import DailyReviewPage from "../pages/mentor/DailyReviewPage";
 
 export const router = createBrowserRouter([
     {
@@ -17,6 +19,8 @@ export const router = createBrowserRouter([
             { path: "/quiz/play", element: <QuizPlayPage /> },
             { path: "/quiz/:quizId/edit", element: <QuizEditPage /> },
             { path: "/routine", element: <RoutinePage /> },
+            { path: "/mentor/plans", element: <MentorPlanPage /> },
+            { path: "/mentor/daily-review", element: <DailyReviewPage /> },
             { path: "/test/health", element: <HealthCheckPage /> },
             { path: "/login", element: <LoginPage /> },
             { path: "*", element: <NotFoundPage /> },

--- a/frontend/src/pages/mentor/DailyReviewPage.jsx
+++ b/frontend/src/pages/mentor/DailyReviewPage.jsx
@@ -8,6 +8,7 @@ import {
     getDailyRoutineSummary,
     saveDailyReflection,
 } from "../../shared/api/mentorApi";
+import MarkdownContent from "../../shared/components/MarkdownContent";
 
 const pageStyle = {
     width: "100%",
@@ -412,7 +413,7 @@ export default function DailyReviewPage() {
                 if (plansResult.status === "fulfilled") {
                     setPlans(plansResult.value);
                 } else {
-                    console.error("AI 멘토 계획 조회 실패:", plansResult.reason);
+                    console.error("멘토 계획 조회 실패:", plansResult.reason);
                     setPlans(null);
                 }
 
@@ -438,7 +439,7 @@ export default function DailyReviewPage() {
                         setFeedback(feedbackResult);
                     }
                 } catch (error) {
-                    console.info("생성된 오늘 AI 멘토 피드백이 아직 없습니다.", error);
+                    console.info("생성된 오늘 멘토 피드백이 아직 없습니다.", error);
                 }
             } finally {
                 if (!ignore) {
@@ -487,10 +488,10 @@ export default function DailyReviewPage() {
             const generatedFeedback = await generateDailyMentorFeedback(todayDate);
 
             setFeedback(generatedFeedback);
-            setMessage("AI 멘토 피드백이 생성되었습니다.");
+            setMessage("멘토 피드백이 생성되었습니다.");
         } catch (error) {
-            console.error("AI 멘토 피드백 생성 실패:", error);
-            alert(getApiErrorMessage(error, "AI 멘토 피드백 생성에 실패했습니다."));
+            console.error("멘토 피드백 생성 실패:", error);
+            alert(getApiErrorMessage(error, "멘토 피드백 생성에 실패했습니다."));
         } finally {
             setSavingAndGenerating(false);
         }
@@ -498,7 +499,7 @@ export default function DailyReviewPage() {
 
     async function handleCopyFeedback() {
         if (!feedback?.feedbackContent) {
-            alert("복사할 AI 멘토 피드백이 없습니다.");
+            alert("복사할 멘토 피드백이 없습니다.");
             return;
         }
 
@@ -507,9 +508,9 @@ export default function DailyReviewPage() {
 
             await navigator.clipboard.writeText(feedback.feedbackContent);
 
-            setMessage("AI 멘토 피드백을 클립보드에 복사했습니다.");
+            setMessage("멘토 피드백을 클립보드에 복사했습니다.");
         } catch (error) {
-            console.error("AI 멘토 피드백 복사 실패:", error);
+            console.error("멘토 피드백 복사 실패:", error);
             alert("복사에 실패했습니다. 브라우저 권한 또는 접속 환경을 확인해주세요.");
         } finally {
             setCopying(false);
@@ -555,7 +556,7 @@ export default function DailyReviewPage() {
                             fontSize: 13,
                         }}
                     >
-                        {todayDate} · 루틴 결과와 소감을 바탕으로 AI 멘토 피드백을 생성합니다.
+                        {todayDate} · 루틴 결과와 소감을 바탕으로 멘토 피드백을 생성합니다.
                     </p>
                 </div>
 
@@ -609,7 +610,7 @@ export default function DailyReviewPage() {
                         lineHeight: 1.6,
                     }}
                 >
-                    AI 멘토 계획이 아직 일부 비어 있습니다. 그래도 피드백 생성은 가능하지만,
+                    멘토 계획이 아직 일부 비어 있습니다. 그래도 피드백 생성은 가능하지만,
                     장기/월간/주간 계획을 입력하면 더 정확한 피드백을 받을 수 있습니다.
                     <div style={{ marginTop: 10 }}>
                         <button
@@ -838,7 +839,7 @@ export default function DailyReviewPage() {
                         cursor: savingAndGenerating || !summary ? "not-allowed" : "pointer",
                     }}
                 >
-                    {savingAndGenerating ? "AI 피드백 생성 중..." : "소감 저장하고 AI 피드백 받기"}
+                    {savingAndGenerating ? "피드백 생성 중..." : "소감 저장하고 멘토 피드백 받기"}
                 </button>
             </section>
 
@@ -860,7 +861,7 @@ export default function DailyReviewPage() {
                             letterSpacing: "-0.04em",
                         }}
                     >
-                        AI 피드백 결과
+                        📌 멘토 피드백 결과
                     </h2>
 
                     <div
@@ -901,25 +902,21 @@ export default function DailyReviewPage() {
                             lineHeight: 1.6,
                         }}
                     >
-                        아직 생성된 AI 멘토 피드백이 없습니다. 오늘 소감을 입력한 뒤 피드백을 생성해주세요.
+                        아직 생성된 멘토 피드백이 없습니다. 오늘 소감을 입력한 뒤 피드백을 생성해주세요.
                     </p>
                 ) : (
-                    <pre
+                    <div
+                        className="mentor-feedback-markdown"
                         style={{
-                            whiteSpace: "pre-wrap",
-                            wordBreak: "break-word",
-                            margin: 0,
-                            lineHeight: 1.7,
-                            fontFamily: "inherit",
-                            fontSize: 15,
                             background: "var(--color-bg)",
                             border: "1px solid var(--color-border)",
                             borderRadius: 14,
                             padding: 14,
+                            overflow: "hidden",
                         }}
                     >
-                        {feedback.feedbackContent}
-                    </pre>
+                        <MarkdownContent value={feedback.feedbackContent} />
+                    </div>
                 )}
             </section>
         </div>

--- a/frontend/src/pages/mentor/DailyReviewPage.jsx
+++ b/frontend/src/pages/mentor/DailyReviewPage.jsx
@@ -1,0 +1,927 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+    generateDailyMentorFeedback,
+    getCurrentMentorPlans,
+    getDailyMentorFeedback,
+    getDailyReflection,
+    getDailyRoutineSummary,
+    saveDailyReflection,
+} from "../../shared/api/mentorApi";
+
+const pageStyle = {
+    width: "100%",
+    maxWidth: 960,
+    margin: "0 auto",
+    padding: "28px clamp(10px, 3vw, 22px) 56px",
+    color: "var(--color-text)",
+    boxSizing: "border-box",
+};
+
+const cardStyle = {
+    width: "100%",
+    boxSizing: "border-box",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-surface)",
+    color: "var(--color-text)",
+    borderRadius: 18,
+    padding: "clamp(16px, 4vw, 22px)",
+};
+
+const softCardStyle = {
+    width: "100%",
+    boxSizing: "border-box",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-surface)",
+    color: "var(--color-text)",
+    borderRadius: 14,
+    padding: 14,
+};
+
+const mutedTextStyle = {
+    color: "var(--color-text-muted)",
+};
+
+const buttonBaseStyle = {
+    border: "1px solid var(--color-border)",
+    background: "var(--color-button-bg)",
+    color: "var(--color-button-text)",
+    padding: "10px 14px",
+    borderRadius: 10,
+    fontWeight: 800,
+    fontSize: 14,
+    cursor: "pointer",
+};
+
+const primaryButtonStyle = {
+    ...buttonBaseStyle,
+    background: "var(--color-primary)",
+    color: "var(--color-bg)",
+};
+
+const accentColors = {
+    blue: "#60a5fa",
+    green: "#22c55e",
+    pink: "#fb7185",
+    amber: "#f59e0b",
+    purple: "#a78bfa",
+    grey: "#f9fafb",
+};
+
+function SummaryMetricCard({
+                               label,
+                               value,
+                               accentColor,
+                           }) {
+    return (
+        <div
+            style={{
+                ...softCardStyle,
+                position: "relative",
+                overflow: "hidden",
+                minHeight: 92,
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "space-between",
+                boxShadow: `inset 4px 0 0 ${accentColor}`,
+            }}
+        >
+            <div
+                style={{
+                    color: "var(--color-text-muted)",
+                    fontSize: 14,
+                    fontWeight: 800,
+                }}
+            >
+                {label}
+            </div>
+
+            <strong
+                style={{
+                    marginTop: 8,
+                    fontSize: 30,
+                    lineHeight: 1,
+                    color: "var(--color-text)",
+                    letterSpacing: "-0.04em",
+                }}
+            >
+                {value}
+            </strong>
+        </div>
+    );
+}
+
+const textareaStyle = {
+    width: "100%",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-bg)",
+    color: "var(--color-text)",
+    borderRadius: 12,
+    padding: "12px 13px",
+    fontSize: 14,
+    boxSizing: "border-box",
+    resize: "vertical",
+    lineHeight: 1.6,
+    minHeight: 82,
+};
+
+function getTodayDateText() {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const date = String(now.getDate()).padStart(2, "0");
+
+    return `${year}-${month}-${date}`;
+}
+
+function getApiErrorMessage(error, fallbackMessage) {
+    return (
+        error?.response?.data?.message ||
+        error?.response?.data?.result?.message ||
+        fallbackMessage
+    );
+}
+
+function formatDateTime(value) {
+    if (!value) return "-";
+
+    return String(value).replace("T", " ").slice(0, 16);
+}
+
+function formatTime(value) {
+    if (!value) return "-";
+
+    return String(value).replace("T", " ").slice(11, 16);
+}
+
+function formatTaskTimeRange(task) {
+    const start = task?.startTime ? String(task.startTime).slice(0, 5) : "";
+    const end = task?.endTime ? String(task.endTime).slice(0, 5) : "";
+
+    if (!start && !end) {
+        return "";
+    }
+
+    return `${start}~${end}`;
+}
+
+function getStatusText(status) {
+    switch (status) {
+        case "COMPLETED":
+            return "완료";
+        case "SKIPPED":
+            return "건너뜀";
+        case "PENDING":
+            return "대기";
+        default:
+            return status ?? "-";
+    }
+}
+
+function getStatusVisual(status) {
+    switch (status) {
+        case "COMPLETED":
+            return {
+                text: "완료",
+                color: "#22c55e",
+                background: "rgba(34, 197, 94, 0.12)",
+                border: "1px solid rgba(34, 197, 94, 0.35)",
+            };
+        case "SKIPPED":
+            return {
+                text: "건너뜀",
+                color: "#f59e0b",
+                background: "rgba(245, 158, 11, 0.12)",
+                border: "1px solid rgba(245, 158, 11, 0.35)",
+            };
+        case "PENDING":
+            return {
+                text: "대기",
+                color: "#fb7185",
+                background: "rgba(251, 113, 133, 0.12)",
+                border: "1px solid rgba(251, 113, 133, 0.35)",
+            };
+        default:
+            return {
+                text: status ?? "-",
+                color: "var(--color-text-muted)",
+                background: "transparent",
+                border: "1px solid var(--color-border)",
+            };
+    }
+}
+
+function TaskList({
+                      title,
+                      icon,
+                      accentColor,
+                      tasks,
+                      emptyText,
+                  }) {
+    return (
+        <div
+            style={{
+                ...softCardStyle,
+                boxShadow: `inset 3px 0 0 ${accentColor}`,
+            }}
+        >
+            <h3
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    marginTop: 0,
+                    marginBottom: 12,
+                    fontSize: 17,
+                    letterSpacing: "-0.04em",
+                }}
+            >
+                <span
+                    aria-hidden="true"
+                    style={{
+                        color: accentColor,
+                        fontSize: 18,
+                    }}
+                >
+                    {icon}
+                </span>
+                {title}
+            </h3>
+
+            {!tasks?.length ? (
+                <p
+                    style={{
+                        ...mutedTextStyle,
+                        margin: 0,
+                        fontSize: 14,
+                        lineHeight: 1.6,
+                    }}
+                >
+                    {emptyText}
+                </p>
+            ) : (
+                <div
+                    style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 10,
+                    }}
+                >
+                    {tasks.map((task, index) => {
+                        const statusVisual = getStatusVisual(task.status);
+
+                        return (
+                            <div
+                                key={`${task.label}-${task.startTime}-${index}`}
+                                style={{
+                                    position: "relative",
+                                    border: "1px solid var(--color-border)",
+                                    background: "var(--color-bg)",
+                                    borderRadius: 14,
+                                    padding: "13px 14px 42px",
+                                    minHeight: 94,
+                                }}
+                            >
+                                <div
+                                    style={{
+                                        display: "flex",
+                                        alignItems: "baseline",
+                                        gap: 8,
+                                        flexWrap: "wrap",
+                                        paddingRight: 8,
+                                    }}
+                                >
+                                    <span
+                                        style={{
+                                            fontSize: 18,
+                                            fontWeight: 900,
+                                            lineHeight: 1.45,
+                                            color: "var(--color-text)",
+                                            wordBreak: "break-word",
+                                            letterSpacing: "-0.035em",
+                                        }}
+                                    >
+                                        {task.taskContent || "할 일 없음"}
+                                    </span>
+
+                                    <span
+                                        style={{
+                                            ...mutedTextStyle,
+                                            fontSize: 12,
+                                            lineHeight: 1.4,
+                                            whiteSpace: "nowrap",
+                                        }}
+                                    >
+                                        {task.label} · {formatTaskTimeRange(task)}
+                                    </span>
+                                </div>
+
+                                {task.completedAt && (
+                                    <div
+                                        style={{
+                                            ...mutedTextStyle,
+                                            position: "absolute",
+                                            left: 14,
+                                            bottom: 14,
+                                            fontSize: 12,
+                                        }}
+                                    >
+                                        완료 처리: {formatDateTime(task.completedAt)}
+                                    </div>
+                                )}
+
+                                <span
+                                    style={{
+                                        position: "absolute",
+                                        right: 14,
+                                        bottom: 12,
+                                        color: statusVisual.color,
+                                        background: statusVisual.background,
+                                        border: statusVisual.border,
+                                        borderRadius: 999,
+                                        padding: "4px 9px",
+                                        fontSize: 12,
+                                        fontWeight: 900,
+                                        whiteSpace: "nowrap",
+                                    }}
+                                >
+                                    {statusVisual.text}
+                                </span>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default function DailyReviewPage() {
+    const navigate = useNavigate();
+
+    const [todayDate] = useState(() => getTodayDateText());
+
+    const [summary, setSummary] = useState(null);
+    const [plans, setPlans] = useState(null);
+    const [reflection, setReflection] = useState({
+        mood: "",
+        good: "",
+        regret: "",
+        freeText: "",
+    });
+    const [feedback, setFeedback] = useState(null);
+
+    const [loading, setLoading] = useState(true);
+    const [savingAndGenerating, setSavingAndGenerating] = useState(false);
+    const [copying, setCopying] = useState(false);
+    const [message, setMessage] = useState("");
+
+    const hasAnyReflectionText = useMemo(() => {
+        return Object.values(reflection).some((value) => value.trim().length > 0);
+    }, [reflection]);
+
+    const hasMissingPlans = useMemo(() => {
+        if (!plans) return false;
+
+        return !plans.careerPlan || !plans.monthlyPlan || !plans.weeklyPlan;
+    }, [plans]);
+
+    useEffect(() => {
+        let ignore = false;
+
+        async function loadDailyReviewData() {
+            try {
+                setLoading(true);
+                setMessage("");
+
+                const [summaryResult, plansResult] = await Promise.allSettled([
+                    getDailyRoutineSummary(todayDate),
+                    getCurrentMentorPlans(),
+                ]);
+
+                if (ignore) return;
+
+                if (summaryResult.status === "fulfilled") {
+                    setSummary(summaryResult.value);
+                } else {
+                    console.error("루틴 요약 조회 실패:", summaryResult.reason);
+                    setSummary(null);
+                    setMessage("오늘 루틴 요약을 불러오지 못했습니다. 오늘 루틴을 먼저 등록해주세요.");
+                }
+
+                if (plansResult.status === "fulfilled") {
+                    setPlans(plansResult.value);
+                } else {
+                    console.error("AI 멘토 계획 조회 실패:", plansResult.reason);
+                    setPlans(null);
+                }
+
+                try {
+                    const reflectionResult = await getDailyReflection(todayDate);
+
+                    if (!ignore) {
+                        setReflection({
+                            mood: reflectionResult?.mood ?? "",
+                            good: reflectionResult?.good ?? "",
+                            regret: reflectionResult?.regret ?? "",
+                            freeText: reflectionResult?.freeText ?? "",
+                        });
+                    }
+                } catch (error) {
+                    console.info("작성된 오늘 소감이 아직 없습니다.", error);
+                }
+
+                try {
+                    const feedbackResult = await getDailyMentorFeedback(todayDate);
+
+                    if (!ignore) {
+                        setFeedback(feedbackResult);
+                    }
+                } catch (error) {
+                    console.info("생성된 오늘 AI 멘토 피드백이 아직 없습니다.", error);
+                }
+            } finally {
+                if (!ignore) {
+                    setLoading(false);
+                }
+            }
+        }
+
+        loadDailyReviewData();
+
+        return () => {
+            ignore = true;
+        };
+    }, [todayDate]);
+
+    function handleChangeReflection(field, value) {
+        setReflection((prev) => ({
+            ...prev,
+            [field]: value,
+        }));
+    }
+
+    async function handleSaveAndGenerateFeedback() {
+        if (!summary) {
+            alert("오늘 루틴 요약이 없습니다. 오늘 루틴을 먼저 등록해주세요.");
+            return;
+        }
+
+        if (!hasAnyReflectionText) {
+            alert("오늘 소감을 한 줄이라도 입력해주세요.");
+            return;
+        }
+
+        try {
+            setSavingAndGenerating(true);
+            setMessage("");
+
+            await saveDailyReflection({
+                reflectionDate: todayDate,
+                mood: reflection.mood.trim(),
+                good: reflection.good.trim(),
+                regret: reflection.regret.trim(),
+                freeText: reflection.freeText.trim(),
+            });
+
+            const generatedFeedback = await generateDailyMentorFeedback(todayDate);
+
+            setFeedback(generatedFeedback);
+            setMessage("AI 멘토 피드백이 생성되었습니다.");
+        } catch (error) {
+            console.error("AI 멘토 피드백 생성 실패:", error);
+            alert(getApiErrorMessage(error, "AI 멘토 피드백 생성에 실패했습니다."));
+        } finally {
+            setSavingAndGenerating(false);
+        }
+    }
+
+    async function handleCopyFeedback() {
+        if (!feedback?.feedbackContent) {
+            alert("복사할 AI 멘토 피드백이 없습니다.");
+            return;
+        }
+
+        try {
+            setCopying(true);
+
+            await navigator.clipboard.writeText(feedback.feedbackContent);
+
+            setMessage("AI 멘토 피드백을 클립보드에 복사했습니다.");
+        } catch (error) {
+            console.error("AI 멘토 피드백 복사 실패:", error);
+            alert("복사에 실패했습니다. 브라우저 권한 또는 접속 환경을 확인해주세요.");
+        } finally {
+            setCopying(false);
+        }
+    }
+
+    if (loading) {
+        return (
+            <div style={pageStyle}>
+                <h1 style={{ margin: 0 }}>오늘 하루 마무리</h1>
+                <p style={mutedTextStyle}>오늘 루틴 결과와 소감을 불러오는 중입니다...</p>
+            </div>
+        );
+    }
+
+    return (
+        <div style={pageStyle}>
+            <header
+                style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: 12,
+                    marginBottom: 14,
+                    flexWrap: "wrap",
+                }}
+            >
+                <div>
+                    <h1
+                        style={{
+                            margin: 0,
+                            fontSize: 28,
+                            letterSpacing: "-0.05em",
+                        }}
+                    >
+                        오늘 하루 마무리
+                    </h1>
+                    <p
+                        style={{
+                            ...mutedTextStyle,
+                            marginTop: 6,
+                            marginBottom: 0,
+                            fontSize: 13,
+                        }}
+                    >
+                        {todayDate} · 루틴 결과와 소감을 바탕으로 AI 멘토 피드백을 생성합니다.
+                    </p>
+                </div>
+
+                <div
+                    style={{
+                        display: "flex",
+                        gap: 8,
+                        flexWrap: "wrap",
+                        justifyContent: "flex-end",
+                    }}
+                >
+                    <button
+                        type="button"
+                        onClick={() => navigate("/mentor/plans")}
+                        style={buttonBaseStyle}
+                    >
+                        🗓️장기계획
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={() => navigate("/routine")}
+                        style={buttonBaseStyle}
+                    >
+                        오늘루틴 돌아가기
+                    </button>
+                </div>
+            </header>
+
+            {message && (
+                <div
+                    style={{
+                        ...softCardStyle,
+                        marginBottom: 12,
+                        color: "var(--color-primary)",
+                        fontSize: 14,
+                        fontWeight: 700,
+                    }}
+                >
+                    {message}
+                </div>
+            )}
+
+            {hasMissingPlans && (
+                <div
+                    style={{
+                        ...softCardStyle,
+                        marginBottom: 12,
+                        color: "var(--color-primary)",
+                        fontSize: 14,
+                        lineHeight: 1.6,
+                    }}
+                >
+                    AI 멘토 계획이 아직 일부 비어 있습니다. 그래도 피드백 생성은 가능하지만,
+                    장기/월간/주간 계획을 입력하면 더 정확한 피드백을 받을 수 있습니다.
+                    <div style={{ marginTop: 10 }}>
+                        <button
+                            type="button"
+                            onClick={() => navigate("/mentor/plans")}
+                            style={buttonBaseStyle}
+                        >
+                            멘토 계획 설정하기
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            <section
+                style={{
+                    ...cardStyle,
+                    marginBottom: 14,
+                }}
+            >
+                <h2
+                    style={{
+                        marginTop: 0,
+                        marginBottom: 12,
+                        fontSize: 20,
+                        letterSpacing: "-0.04em",
+                    }}
+                >
+                    오늘 루틴 결과 요약
+                </h2>
+
+                {!summary ? (
+                    <div style={softCardStyle}>
+                        <p
+                            style={{
+                                ...mutedTextStyle,
+                                marginTop: 0,
+                                lineHeight: 1.6,
+                            }}
+                        >
+                            오늘 루틴 결과를 불러오지 못했습니다. 오늘 루틴을 먼저 등록한 뒤 다시 시도해주세요.
+                        </p>
+
+                        <button
+                            type="button"
+                            onClick={() => navigate("/routine")}
+                            style={primaryButtonStyle}
+                        >
+                            오늘 루틴 등록하러 가기
+                        </button>
+                    </div>
+                ) : (
+                    <>
+                        <div
+                            style={{
+                                display: "grid",
+                                gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+                                gap: 10,
+                                marginBottom: 14,
+                            }}
+                        >
+                            <SummaryMetricCard
+                                label="전체 Task"
+                                value={summary.totalCount}
+                                //accentColor={accentColors.grey}
+                            />
+
+                            <SummaryMetricCard
+                                label="완료"
+                                value={summary.completedCount}
+                                //accentColor={accentColors.grey}
+                            />
+
+                            <SummaryMetricCard
+                                label="미완료"
+                                value={(summary.pendingCount ?? 0) + (summary.skippedCount ?? 0)}
+                                //accentColor={accentColors.grey}
+                            />
+
+                            <SummaryMetricCard
+                                label="완료율"
+                                value={`${summary.completionRate}%`}
+                                //accentColor={accentColors.grey}
+                            />
+
+                            <SummaryMetricCard
+                                label="계획 등록"
+                                value={formatTime(summary.plannedAt)}
+                                //accentColor={accentColors.grey}
+                            />
+                        </div>
+
+                        <div
+                            style={{
+                                display: "grid",
+                                gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+                                gap: 12,
+                            }}
+                        >
+                            <TaskList
+                                title="⭕ 완료한 일"
+                                tasks={summary.completedTasks}
+                                emptyText="아직 완료한 일이 없습니다."
+                            />
+
+                            <TaskList
+                                title="❌ 미완료한 일"
+                                tasks={summary.uncompletedTasks}
+                                emptyText="미완료한 일이 없습니다."
+                            />
+                        </div>
+                    </>
+                )}
+            </section>
+
+            <section
+                style={{
+                    ...cardStyle,
+                    marginBottom: 14,
+                }}
+            >
+                <h2
+                    style={{
+                        marginTop: 0,
+                        marginBottom: 12,
+                        fontSize: 20,
+                        letterSpacing: "-0.04em",
+                    }}
+                >
+                    오늘 소감 입력
+                </h2>
+
+                <div
+                    style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 14,
+                    }}
+                >
+                    <label
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 8,
+                            fontSize: 14,
+                            fontWeight: 800,
+                        }}
+                    >
+                        컨디션/감정
+                        <textarea
+                            value={reflection.mood}
+                            onChange={(event) => handleChangeReflection("mood", event.target.value)}
+                            placeholder="예: 조금 지쳤지만 끝까지 붙잡았다."
+                            style={textareaStyle}
+                        />
+                    </label>
+
+                    <label
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 8,
+                            fontSize: 14,
+                            fontWeight: 800,
+                        }}
+                    >
+                        잘한 점
+                        <textarea
+                            value={reflection.good}
+                            onChange={(event) => handleChangeReflection("good", event.target.value)}
+                            placeholder="예: 루틴 시계 기능을 많이 완성했다."
+                            style={textareaStyle}
+                        />
+                    </label>
+
+                    <label
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 8,
+                            fontSize: 14,
+                            fontWeight: 800,
+                        }}
+                    >
+                        아쉬운 점
+                        <textarea
+                            value={reflection.regret}
+                            onChange={(event) => handleChangeReflection("regret", event.target.value)}
+                            placeholder="예: 야자 시간대 집중이 떨어졌다."
+                            style={textareaStyle}
+                        />
+                    </label>
+
+                    <label
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 8,
+                            fontSize: 14,
+                            fontWeight: 800,
+                        }}
+                    >
+                        자유 소감
+                        <textarea
+                            value={reflection.freeText}
+                            onChange={(event) => handleChangeReflection("freeText", event.target.value)}
+                            placeholder="예: 오늘은 중간에 흔들렸지만 그래도 끝까지 붙잡았다."
+                            style={{
+                                ...textareaStyle,
+                                minHeight: 130,
+                            }}
+                        />
+                    </label>
+                </div>
+
+                <button
+                    type="button"
+                    onClick={handleSaveAndGenerateFeedback}
+                    disabled={savingAndGenerating || !summary}
+                    style={{
+                        ...primaryButtonStyle,
+                        width: "100%",
+                        marginTop: 16,
+                        padding: "13px 14px",
+                        fontSize: 15,
+                        opacity: savingAndGenerating || !summary ? 0.65 : 1,
+                        cursor: savingAndGenerating || !summary ? "not-allowed" : "pointer",
+                    }}
+                >
+                    {savingAndGenerating ? "AI 피드백 생성 중..." : "소감 저장하고 AI 피드백 받기"}
+                </button>
+            </section>
+
+            <section style={cardStyle}>
+                <div
+                    style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        gap: 12,
+                        marginBottom: 12,
+                        flexWrap: "wrap",
+                    }}
+                >
+                    <h2
+                        style={{
+                            margin: 0,
+                            fontSize: 20,
+                            letterSpacing: "-0.04em",
+                        }}
+                    >
+                        AI 피드백 결과
+                    </h2>
+
+                    <div
+                        style={{
+                            display: "flex",
+                            gap: 8,
+                            flexWrap: "wrap",
+                        }}
+                    >
+                        <button
+                            type="button"
+                            onClick={handleCopyFeedback}
+                            disabled={copying || !feedback?.feedbackContent}
+                            style={{
+                                ...buttonBaseStyle,
+                                opacity: copying || !feedback?.feedbackContent ? 0.65 : 1,
+                                cursor: copying || !feedback?.feedbackContent ? "not-allowed" : "pointer",
+                            }}
+                        >
+                            {copying ? "복사 중..." : "복사하기"}
+                        </button>
+
+                        <button
+                            type="button"
+                            onClick={() => navigate("/routine")}
+                            style={buttonBaseStyle}
+                        >
+                            오늘루틴 돌아가기
+                        </button>
+                    </div>
+                </div>
+
+                {!feedback?.feedbackContent ? (
+                    <p
+                        style={{
+                            ...mutedTextStyle,
+                            margin: 0,
+                            lineHeight: 1.6,
+                        }}
+                    >
+                        아직 생성된 AI 멘토 피드백이 없습니다. 오늘 소감을 입력한 뒤 피드백을 생성해주세요.
+                    </p>
+                ) : (
+                    <pre
+                        style={{
+                            whiteSpace: "pre-wrap",
+                            wordBreak: "break-word",
+                            margin: 0,
+                            lineHeight: 1.7,
+                            fontFamily: "inherit",
+                            fontSize: 15,
+                            background: "var(--color-bg)",
+                            border: "1px solid var(--color-border)",
+                            borderRadius: 14,
+                            padding: 14,
+                        }}
+                    >
+                        {feedback.feedbackContent}
+                    </pre>
+                )}
+            </section>
+        </div>
+    );
+}

--- a/frontend/src/pages/mentor/MentorPlanPage.jsx
+++ b/frontend/src/pages/mentor/MentorPlanPage.jsx
@@ -1,0 +1,309 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+    getCurrentMentorPlans,
+    saveMentorPlan,
+} from "../../shared/api/mentorApi";
+
+const pageStyle = {
+    width: "100%",
+    maxWidth: 920,
+    margin: "0 auto",
+    padding: "28px clamp(10px, 3vw, 22px) 56px",
+    color: "var(--color-text)",
+    boxSizing: "border-box",
+};
+
+const cardStyle = {
+    width: "100%",
+    boxSizing: "border-box",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-surface)",
+    color: "var(--color-text)",
+    borderRadius: 18,
+    padding: "clamp(16px, 4vw, 22px)",
+};
+
+const softCardStyle = {
+    width: "100%",
+    boxSizing: "border-box",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-surface)",
+    color: "var(--color-text)",
+    borderRadius: 14,
+    padding: 14,
+};
+
+const mutedTextStyle = {
+    color: "var(--color-text-muted)",
+};
+
+const buttonBaseStyle = {
+    border: "1px solid var(--color-border)",
+    background: "var(--color-button-bg)",
+    color: "var(--color-button-text)",
+    padding: "10px 14px",
+    borderRadius: 10,
+    fontWeight: 800,
+    fontSize: 14,
+    cursor: "pointer",
+};
+
+const primaryButtonStyle = {
+    ...buttonBaseStyle,
+    background: "var(--color-primary)",
+    color: "var(--color-bg)",
+};
+
+const textareaStyle = {
+    width: "100%",
+    border: "1px solid var(--color-border)",
+    background: "var(--color-bg)",
+    color: "var(--color-text)",
+    borderRadius: 12,
+    padding: "12px 13px",
+    fontSize: 14,
+    boxSizing: "border-box",
+    resize: "vertical",
+    lineHeight: 1.6,
+    minHeight: 130,
+};
+
+function getApiErrorMessage(error, fallbackMessage) {
+    return (
+        error?.response?.data?.message ||
+        error?.response?.data?.result?.message ||
+        fallbackMessage
+    );
+}
+
+export default function MentorPlanPage() {
+    const navigate = useNavigate();
+
+    const [careerPlan, setCareerPlan] = useState("");
+    const [monthlyPlan, setMonthlyPlan] = useState("");
+    const [weeklyPlan, setWeeklyPlan] = useState("");
+
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [message, setMessage] = useState("");
+
+    useEffect(() => {
+        let ignore = false;
+
+        async function loadPlans() {
+            try {
+                setLoading(true);
+                setMessage("");
+
+                const data = await getCurrentMentorPlans();
+
+                if (ignore) return;
+
+                setCareerPlan(data?.careerPlan?.content ?? "");
+                setMonthlyPlan(data?.monthlyPlan?.content ?? "");
+                setWeeklyPlan(data?.weeklyPlan?.content ?? "");
+            } catch (error) {
+                if (ignore) return;
+
+                console.error("AI 멘토 계획 조회 실패:", error);
+                setMessage("기존 AI 멘토 계획을 불러오지 못했습니다. 새로 입력해도 됩니다.");
+            } finally {
+                if (!ignore) {
+                    setLoading(false);
+                }
+            }
+        }
+
+        loadPlans();
+
+        return () => {
+            ignore = true;
+        };
+    }, []);
+
+    async function handleSavePlans() {
+        try {
+            setSaving(true);
+            setMessage("");
+
+            await saveMentorPlan("CAREER", {
+                content: careerPlan.trim(),
+            });
+
+            await saveMentorPlan("MONTHLY", {
+                content: monthlyPlan.trim(),
+            });
+
+            await saveMentorPlan("WEEKLY", {
+                content: weeklyPlan.trim(),
+            });
+
+            setMessage("AI 멘토 계획이 저장되었습니다.");
+        } catch (error) {
+            console.error("AI 멘토 계획 저장 실패:", error);
+            alert(getApiErrorMessage(error, "AI 멘토 계획 저장에 실패했습니다."));
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    if (loading) {
+        return (
+            <div style={pageStyle}>
+                <h1 style={{ margin: 0 }}>AI 멘토 계획 설정</h1>
+                <p style={mutedTextStyle}>AI 멘토 계획을 불러오는 중입니다...</p>
+            </div>
+        );
+    }
+
+    return (
+        <div style={pageStyle}>
+            <header
+                style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: 12,
+                    marginBottom: 14,
+                    flexWrap: "wrap",
+                }}
+            >
+                <div>
+                    <h1
+                        style={{
+                            margin: 0,
+                            fontSize: 28,
+                            letterSpacing: "-0.05em",
+                        }}
+                    >
+                        AI 멘토 계획 설정
+                    </h1>
+                    <p
+                        style={{
+                            ...mutedTextStyle,
+                            marginTop: 6,
+                            marginBottom: 0,
+                            fontSize: 13,
+                            lineHeight: 1.5,
+                        }}
+                    >
+                        AI 멘토가 매일 피드백할 때 참고할 장기/월간/주간 계획을 저장합니다.
+                    </p>
+                </div>
+
+                <div
+                    style={{
+                        display: "flex",
+                        gap: 8,
+                        flexWrap: "wrap",
+                        justifyContent: "flex-end",
+                    }}
+                >
+                    <button
+                        type="button"
+                        onClick={() => navigate("/routine")}
+                        style={buttonBaseStyle}
+                    >
+                        오늘루틴 돌아가기
+                    </button>
+                </div>
+            </header>
+
+            {message && (
+                <div
+                    style={{
+                        ...softCardStyle,
+                        marginBottom: 12,
+                        color: "var(--color-primary)",
+                        fontSize: 14,
+                        fontWeight: 700,
+                    }}
+                >
+                    {message}
+                </div>
+            )}
+
+            <section style={cardStyle}>
+                <div
+                    style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 18,
+                    }}
+                >
+                    <label
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 8,
+                            fontSize: 14,
+                            fontWeight: 800,
+                        }}
+                    >
+                        취업 전반 계획
+                        <textarea
+                            value={careerPlan}
+                            onChange={(event) => setCareerPlan(event.target.value)}
+                            placeholder="예: 2027년 상반기 백엔드 신입 취업. Java/Spring, CS, 프로젝트 운영 경험, 면접 말하기를 핵심으로 준비한다."
+                            style={textareaStyle}
+                        />
+                    </label>
+
+                    <label
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 8,
+                            fontSize: 14,
+                            fontWeight: 800,
+                        }}
+                    >
+                        이번달 계획
+                        <textarea
+                            value={monthlyPlan}
+                            onChange={(event) => setMonthlyPlan(event.target.value)}
+                            placeholder="예: 루틴 시계 MVP 완성, AI 멘토 피드백 구현, Redis 분산락 프로젝트 설명 정리."
+                            style={textareaStyle}
+                        />
+                    </label>
+
+                    <label
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 8,
+                            fontSize: 14,
+                            fontWeight: 800,
+                        }}
+                    >
+                        이번주 계획
+                        <textarea
+                            value={weeklyPlan}
+                            onChange={(event) => setWeeklyPlan(event.target.value)}
+                            placeholder="예: 백엔드 API 검증, 프론트 연동, 매일 문제 복습, PR 정리."
+                            style={textareaStyle}
+                        />
+                    </label>
+                </div>
+
+                <button
+                    type="button"
+                    onClick={handleSavePlans}
+                    disabled={saving}
+                    style={{
+                        ...primaryButtonStyle,
+                        width: "100%",
+                        marginTop: 18,
+                        padding: "13px 14px",
+                        fontSize: 15,
+                        opacity: saving ? 0.65 : 1,
+                        cursor: saving ? "not-allowed" : "pointer",
+                    }}
+                >
+                    {saving ? "저장 중..." : "저장하기"}
+                </button>
+            </section>
+        </div>
+    );
+}

--- a/frontend/src/pages/routine/RoutinePage.jsx
+++ b/frontend/src/pages/routine/RoutinePage.jsx
@@ -999,14 +999,15 @@ export default function RoutinePage() {
         setIsEditMode(true);
     }
 
-    function handleCancelEdit() {
+    function handleBackToRoutineClock() {
         if (!routine) {
-            navigate("/");
+            alert("아직 저장된 오늘 루틴이 없습니다. 먼저 오늘 루틴을 저장해주세요.");
             return;
         }
 
         setFormPeriods(toFormPeriods(routine.periods));
         setIsEditMode(false);
+        setMessage("");
     }
 
     async function handleSaveRoutine() {
@@ -1114,22 +1115,37 @@ export default function RoutinePage() {
                         justifyContent: "flex-end",
                     }}
                 >
-                    <button
-                        type="button"
-                        onClick={() => navigate("/")}
-                        style={buttonBaseStyle}
-                    >
-                        홈
-                    </button>
-
-                    {!isEditMode && (
+                    {isEditMode ? (
                         <button
                             type="button"
-                            onClick={handleStartEdit}
-                            style={primaryButtonStyle}
+                            onClick={handleBackToRoutineClock}
+                            disabled={!routine}
+                            style={{
+                                ...buttonBaseStyle,
+                                opacity: !routine ? 0.65 : 1,
+                                cursor: !routine ? "not-allowed" : "pointer",
+                            }}
                         >
-                            루틴 수정
+                            오늘루틴 돌아가기
                         </button>
+                    ) : (
+                        <>
+                            <button
+                                type="button"
+                                onClick={() => navigate("/")}
+                                style={buttonBaseStyle}
+                            >
+                                홈
+                            </button>
+
+                            <button
+                                type="button"
+                                onClick={() => navigate("/mentor/plans")}
+                                style={buttonBaseStyle}
+                            >
+                                🗓️장기계획
+                            </button>
+                        </>
                     )}
                 </div>
             </header>
@@ -1410,11 +1426,15 @@ export default function RoutinePage() {
 
                         <button
                             type="button"
-                            onClick={handleCancelEdit}
-                            disabled={saving}
-                            style={buttonBaseStyle}
+                            onClick={handleBackToRoutineClock}
+                            disabled={saving || !routine}
+                            style={{
+                                ...buttonBaseStyle,
+                                opacity: saving || !routine ? 0.65 : 1,
+                                cursor: saving || !routine ? "not-allowed" : "pointer",
+                            }}
                         >
-                            취소
+                            오늘루틴 돌아가기
                         </button>
                     </div>
                 </section>
@@ -1590,6 +1610,7 @@ export default function RoutinePage() {
                                 alignItems: "center",
                                 gap: 12,
                                 marginBottom: 12,
+                                flexWrap: "wrap",
                             }}
                         >
                             <h2
@@ -1602,14 +1623,38 @@ export default function RoutinePage() {
                                 오늘 루틴 목록
                             </h2>
 
-                            <span
+                            <div
                                 style={{
-                                    ...mutedTextStyle,
-                                    fontSize: 13,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    gap: 8,
+                                    flexWrap: "wrap",
+                                    justifyContent: "flex-end",
                                 }}
                             >
-                                {orderedPeriods.length}개 구간
-                            </span>
+                                <span
+                                    style={{
+                                        ...mutedTextStyle,
+                                        fontSize: 13,
+                                        whiteSpace: "nowrap",
+                                    }}
+                                >
+                                    {orderedPeriods.length}개 구간
+                                </span>
+
+                                <button
+                                    type="button"
+                                    onClick={handleStartEdit}
+                                    style={{
+                                        ...buttonBaseStyle,
+                                        padding: "7px 10px",
+                                        fontSize: 12,
+                                        borderRadius: 999,
+                                    }}
+                                >
+                                    ✏️ 루틴 수정
+                                </button>
+                            </div>
                         </div>
 
                         <div
@@ -1695,6 +1740,19 @@ export default function RoutinePage() {
                                 );
                             })}
                         </div>
+                        <button
+                            type="button"
+                            onClick={() => navigate("/mentor/daily-review")}
+                            style={{
+                                ...primaryButtonStyle,
+                                width: "100%",
+                                marginTop: 16,
+                                padding: "13px 14px",
+                                fontSize: 15,
+                            }}
+                        >
+                            하루 마무리하고 AI 피드백 받기
+                        </button>
                     </section>
                 </>
             )}

--- a/frontend/src/shared/api/mentorApi.js
+++ b/frontend/src/shared/api/mentorApi.js
@@ -37,6 +37,7 @@ export async function getDailyReflection(date) {
 export async function generateDailyMentorFeedback(date) {
     const response = await apiClient.post("/api/v1/mentor/feedbacks/daily", null, {
         params: { date },
+        timeout: 180000,
     });
 
     return response.data.result;

--- a/frontend/src/shared/api/mentorApi.js
+++ b/frontend/src/shared/api/mentorApi.js
@@ -1,0 +1,51 @@
+import { apiClient } from "./client";
+
+export async function saveMentorPlan(type, payload) {
+    const response = await apiClient.put(`/api/v1/mentor/plans/${type}`, payload);
+
+    return response.data.result;
+}
+
+export async function getCurrentMentorPlans() {
+    const response = await apiClient.get("/api/v1/mentor/plans/current");
+
+    return response.data.result;
+}
+
+export async function getDailyRoutineSummary(date) {
+    const response = await apiClient.get("/api/v1/mentor/routine-summary/daily", {
+        params: { date },
+    });
+
+    return response.data.result;
+}
+
+export async function saveDailyReflection(payload) {
+    const response = await apiClient.put("/api/v1/mentor/reflections/daily", payload);
+
+    return response.data.result;
+}
+
+export async function getDailyReflection(date) {
+    const response = await apiClient.get("/api/v1/mentor/reflections/daily", {
+        params: { date },
+    });
+
+    return response.data.result;
+}
+
+export async function generateDailyMentorFeedback(date) {
+    const response = await apiClient.post("/api/v1/mentor/feedbacks/daily", null, {
+        params: { date },
+    });
+
+    return response.data.result;
+}
+
+export async function getDailyMentorFeedback(date) {
+    const response = await apiClient.get("/api/v1/mentor/feedbacks/daily", {
+        params: { date },
+    });
+
+    return response.data.result;
+}

--- a/frontend/src/shared/components/MarkdownContent.css
+++ b/frontend/src/shared/components/MarkdownContent.css
@@ -90,3 +90,28 @@
 .markdown-content > :last-child {
     margin-bottom: 0;
 }
+
+.mentor-feedback-markdown .markdown-content h2,
+.mentor-feedback-markdown .markdown-content h3 {
+    display: table;
+    width: fit-content;
+    max-width: 100%;
+    background: #333333;
+    color: #BBBBBB;
+    padding: 4px 8px;
+    border-radius: 6px;
+    margin: 10px 0 14px;
+    font-weight: 900;
+    line-height: 1.2;
+}
+
+.mentor-feedback-markdown .markdown-content p,
+.mentor-feedback-markdown .markdown-content li {
+    color: #d6d3d1;
+}
+
+.mentor-feedback-markdown .markdown-content hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: 22px 0;
+}


### PR DESCRIPTION
## 📝 작업 내용 설명

이번 PR에서는 오늘 루틴 수행 데이터를 기반으로 하루를 마무리할 때 AI 멘토 피드백을 생성하고 확인할 수 있는 MVP를 구현했습니다.

기존에는 사용자가 오늘 루틴 시계를 통해 하루 계획을 등록하고, 각 시간 구간별 할 일을 수행하며 완료 여부를 기록할 수 있었습니다.

이번 작업에서는 이 루틴 수행 결과에 장기/월간/주간 계획, 오늘 소감, 루틴 등록 시각, 소감 작성 시각, 루틴 구간 완료 시각을 함께 조합하여 실제 LLM 기반 AI 멘토 피드백을 생성하도록 확장했습니다.

AI 멘토는 단순히 완료한 일만 확인하는 것이 아니라, 사용자의 장기 취업 목표와 오늘의 실행 결과를 연결해 칭찬, 아쉬운 점, 현실적인 쓴소리, 내일 행동 지시를 제공합니다.

이번 PR에서는 카카오톡 전송까지는 구현하지 않고, 웹 화면에서 피드백을 생성하고 DB에 저장한 뒤 사용자가 확인/복사할 수 있는 MVP 흐름을 구현했습니다.

## ✅ 작업 내용

* [x] AI 멘토 계획 저장 도메인 추가
* [x] 장기/월간/주간 계획 타입 추가

  * `CAREER`
  * `MONTHLY`
  * `WEEKLY`
* [x] AI 멘토 계획 저장/조회 API 구현
* [x] 오늘 소감 저장 도메인 추가
* [x] 오늘 컨디션/감정, 잘한 점, 아쉬운 점, 자유 소감 저장
* [x] 오늘 소감 작성 시각 기록
* [x] 오늘 소감 저장/조회 API 구현
* [x] 오늘 루틴 최초 등록 시각 `plannedAt` 기록
* [x] 오늘 루틴 마지막 수정 시각 `lastModifiedAt` 기록
* [x] 루틴 수정 시 최초 등록 시각은 유지되도록 처리
* [x] 루틴 구간 완료 처리 시 `completedAt` 기록
* [x] 루틴 구간 대기 복구 시 `completedAt` 초기화
* [x] 오늘 루틴 결과 요약 API 구현
* [x] 완료/미완료 구간 수, 완료율, 완료한 일 목록, 미완료한 일 목록 집계
* [x] 휴식 구간은 루틴 수행 대상 집계에서 제외
* [x] AI 멘토 피드백 저장 도메인 추가
* [x] 피드백 날짜, 프롬프트 스냅샷, 피드백 내용, 생성 시각, 전송 상태 저장
* [x] 실제 OpenAI API 기반 AI 멘토 피드백 생성 연동
* [x] OpenAI API Key, 모델명, timeout, max output token 환경변수 설정 추가
* [x] GitHub Actions 배포 시 OpenAI 환경변수 주입 설정 추가
* [x] AI 멘토 피드백 생성/조회 API 구현
* [x] AI 멘토 피드백 프롬프트 출력 형식 개선
* [x] AI 멘토 피드백 마크다운 출력 및 렌더링 적용
* [x] 프론트엔드 AI 멘토 API 클라이언트 추가
* [x] AI 멘토 계획 입력 화면 구현
* [x] 오늘 하루 마무리/소감 입력 화면 구현
* [x] 오늘 루틴 결과 요약 화면 구현
* [x] AI 멘토 피드백 생성 버튼 구현
* [x] 피드백 생성 중 로딩 상태 및 실패 처리 구현
* [x] 생성된 피드백 화면 표시
* [x] 생성된 피드백 클립보드 복사 기능 구현
* [x] 오늘 루틴 화면에서 멘토 계획/하루 마무리 화면으로 이동할 수 있도록 연결

## 🔍 주요 변경 포인트

* `domain/mentor` 영역을 추가하여 AI 멘토 계획, 일일 소감, 일일 피드백 생성 흐름을 분리했습니다.
* `MentorPlan`을 통해 취업 전반 계획, 이번달 계획, 이번주 계획을 저장하고 현재 적용 중인 계획을 조회할 수 있도록 했습니다.
* `DailyReflection`을 통해 하루 마무리 소감과 소감 작성 시각을 저장하도록 했습니다.
* `DailyRoutine`에 `plannedAt`, `lastModifiedAt`을 추가하여 오늘 계획 등록/수정 시각을 기록하도록 했습니다.
* `RoutinePeriod`에 `completedAt`을 활용하여 각 루틴 구간의 완료 처리 시각을 AI 피드백 데이터로 사용할 수 있도록 했습니다.
* `RoutineSummaryService`를 통해 오늘 루틴 수행 결과를 AI 피드백용 요약 데이터로 조합했습니다.
* 휴식 구간은 실제 수행 대상이 아니므로 전체 Task, 완료, 미완료 집계에서 제외했습니다.
* `DailyMentorFeedback`에 생성 당시 프롬프트 스냅샷과 LLM 응답 내용을 저장하도록 했습니다.
* `MentorFeedbackGenerator` 인터페이스를 기준으로 Fake 구현체와 OpenAI 구현체를 분리했습니다.
* `OpenAiMentorFeedbackGenerator`를 추가하여 실제 OpenAI API를 통해 AI 멘토 피드백을 생성하도록 했습니다.
* OpenAI 응답 처리 과정에서 JsonNode 변환 문제를 수정하고, LLM 응답 텍스트 추출 로직을 보강했습니다.
* 프롬프트는 사용자의 장기 목표, 월간 계획, 주간 계획, 오늘 루틴 결과, 오늘 소감을 계층적으로 전달하도록 구성했습니다.
* 피드백은 마크다운 형식으로 생성하고, 프론트에서 `MarkdownContent` 컴포넌트로 렌더링하도록 개선했습니다.
* 프론트 하루 마무리 화면에서는 루틴 결과 요약, 완료/미완료 작업 목록, 오늘 소감 입력, 피드백 생성/복사 흐름을 한 화면에서 처리하도록 구성했습니다.
* 피드백 결과 UI는 모바일 화면에서도 읽기 쉽도록 카드, 문단, 제목, 목록 스타일을 정리했습니다.

## 🧪 확인한 내용

* [x] 로컬 환경에서 백엔드 서버 정상 실행 확인
* [x] Swagger에서 AI 멘토 계획 저장/조회 API 확인
* [x] Swagger에서 오늘 소감 저장/조회 API 확인
* [x] Swagger에서 오늘 루틴 결과 요약 API 확인
* [x] Swagger에서 AI 멘토 피드백 생성/조회 API 확인
* [x] 실제 OpenAI API 호출을 통한 피드백 생성 확인
* [x] 생성된 피드백이 DB에 저장되는 것 확인
* [x] 생성된 피드백 응답에 `promptSnapshot`, `feedbackContent`, `generatedAt`, `sendStatus`가 포함되는 것 확인
* [x] 오늘 루틴 저장 시 `plannedAt`이 기록되는 것 확인
* [x] 오늘 루틴 수정 시 `lastModifiedAt`이 갱신되는 것 확인
* [x] 루틴 수정 시 최초 등록 시각 `plannedAt`이 유지되는 것 확인
* [x] 루틴 구간 완료 처리 시 `completedAt`이 기록되는 것 확인
* [x] 루틴 구간 대기 복구 시 `completedAt`이 초기화되는 것 확인
* [x] 휴식 구간이 루틴 요약 집계에서 제외되는 것 확인
* [x] 프론트에서 멘토 계획 설정 화면 진입 및 저장 확인
* [x] 프론트에서 오늘 하루 마무리 화면 진입 확인
* [x] 프론트에서 루틴 결과 요약 카드 표시 확인
* [x] 프론트에서 완료한 일/미완료한 일 목록 표시 확인
* [x] 프론트에서 오늘 소감 입력 후 피드백 생성 확인
* [x] 프론트에서 생성된 멘토 피드백이 마크다운 형식으로 표시되는 것 확인
* [x] 프론트에서 피드백 복사 기능 동작 확인
* [x] 피드백 생성 실패 시 에러 메시지 표시 확인
* [x] 모바일 화면 기준 주요 UI 배치 확인

## 📌 비고

이번 PR은 AI 데일리 멘토 피드백 MVP 구현에 집중합니다.

다음 기능들은 이번 PR 범위에서 제외했습니다.

* 카카오톡 자동 전송
* 보호자/주변인 자동 공유
* 매일 정해진 시간에 자동 피드백 생성
* 주간 회고 리포트
* 월간 성장 리포트
* 루틴 통계 대시보드
* 실제 기상 시각/취침 시각 직접 입력

다만 추후 확장을 고려해 다음 정보는 저장 구조와 프롬프트 구성에 반영했습니다.

* 오늘 계획 등록 시각
* 오늘 계획 마지막 수정 시각
* 오늘 소감 작성 시각
* 루틴 구간 완료 시각
* AI 피드백 생성 당시의 프롬프트 스냅샷
* 카카오톡 전송 상태 확장 필드

현재 개발 편의를 위해 일부 API 접근/CSRF 정책이 임시 허용되어 있다면, 운영 배포 전 인증 정책과 CSRF 처리 방식을 다시 점검해야 합니다.

OpenAI API Key는 코드에 직접 포함하지 않고 환경변수 및 GitHub Secrets를 통해 주입합니다.

## 🔗 관련 이슈

closes #81
